### PR TITLE
[IMP mrp_operation_with_quality_test]

### DIFF
--- a/mrp_operation_with_quality_test/models/mrp.py
+++ b/mrp_operation_with_quality_test/models/mrp.py
@@ -154,7 +154,7 @@ class MrpProductionWorkcenterLine(models.Model):
     def action_done(self):
         if self.test_ids:
             for test in self.test_ids:
-                if test.state not in ('success', 'failed'):
+                if test.state not in ('success', 'failed', 'canceled'):
                     raise except_orm(_('Finalization Operation Error!'),
                                      _("The Operation has quality test without"
                                        "QUALITY SUCCESS state"))

--- a/mrp_operation_with_quality_test/views/mrp_production_workcenter_line_view.xml
+++ b/mrp_operation_with_quality_test/views/mrp_production_workcenter_line_view.xml
@@ -25,7 +25,7 @@
             <field name="model">mrp.production</field>
             <field name="inherit_id" ref="mrp_operations_extension.mrp_production_form_view_inh"/>
             <field name="arch" type="xml">
-                <page string="Product Lines" position="after" >
+                <page string="Information" position="after" >
                     <page string="Quality Test" attrs="{'invisible': [('required_test','=',False)]}">
                         <field name="test_ids" nolabel="1" colspan="4"/>
                     </page>


### PR DESCRIPTION
Se ha modificado el módulo para que solo se pueda finalizar la operación, si no tiene operaciones, o si tiene operaciones, que estas estén en estado cancelado, ok, o no ok.
