### PR TITLE
[IMP] mrp_bom_component_change Añadido domain en BoM list

### DIFF
--- a/mrp_bom_component_change/models/mrp_bom_change.py
+++ b/mrp_bom_component_change/models/mrp_bom_change.py
@@ -25,7 +25,7 @@ from datetime import datetime as dt
 
 class MrpBomChange(models.Model):
     _name = 'mrp.bom.change'
-    _descrition = 'Mrp BoM Component Change'
+    _description = 'Mrp BoM Component Change'
 
     name = fields.Char('Name', required=True)
     new_component = fields.Many2one('product.product', 'New Component')

--- a/mrp_bom_component_change/models/mrp_bom_change.py
+++ b/mrp_bom_component_change/models/mrp_bom_change.py
@@ -38,7 +38,7 @@ class MrpBomChange(models.Model):
     date = fields.Date('Change Date', readonly=True)
     user = fields.Many2one('res.users', 'Changed By', readonly=True)
 
-    @api.one
+    @api.multi
     @api.onchange('old_component')
     def onchange_operation(self):
         if self.old_component:
@@ -52,6 +52,7 @@ class MrpBomChange(models.Model):
             self.boms = bom_lst
             if self.state != 'process':
                 self.state = 'process'
+        return {'domain': {'boms': [('id', 'in', bom_lst)]}}
 
     @api.one
     def do_component_change(self):


### PR DESCRIPTION
Al final he hecho un apaño en el on_change al seleccionar el componente a modificar,  generé el domain.
Lo único que si se sale del objeto o se recarga la vista no se regenera.
He tratado de pasar los datos por el contexto tal y como pones en el ejemplo del issue #133, pero con la nueva API no hay forma de pasar el context, con todas las pruebas que hecho siempre me salía sin los datos que le pasaba, de todas formas gracias por la ayuda.
