### PR TITLE
[ADD] sale_delivery_date

### DIFF
--- a/sale_delivery_date/__init__.py
+++ b/sale_delivery_date/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/sale_delivery_date/__openerp__.py
+++ b/sale_delivery_date/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Sale - Delivery date",
+    "version": "1.0",
+    "depends": [
+        "sale",
+    ],
+    "author": "OdooMRP team",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+    ],
+    "category": "Custom Module",
+    "website": "http://www.odoomrp.com",
+    "summary": "Delivery date on sale orders",
+    "description": """
+This module creates:
+    * a field 'delivery_date' on sale.order
+    * a field 'delivery_date' on sale.order.line which default is sale.order's
+      'delivery_date'
+
+    """,
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_delivery_date/__openerp__.py
+++ b/sale_delivery_date/__openerp__.py
@@ -32,7 +32,7 @@
     "description": """
 This module creates:
     * a field 'delivery_date' on sale.order
-    * a field 'delivery_date' on sale.order.line which default is sale.order's
+    * a field 'delivery_date' on sale.order.line whose default is sale.order's
       'delivery_date'
 
     TODO: Take this into account for the procurements...

--- a/sale_delivery_date/__openerp__.py
+++ b/sale_delivery_date/__openerp__.py
@@ -35,6 +35,7 @@ This module creates:
     * a field 'delivery_date' on sale.order.line which default is sale.order's
       'delivery_date'
 
+    TODO: Take this into account for the procurements...
     """,
     "data": [
         "views/sale_order_view.xml",

--- a/sale_delivery_date/models/__init__.py
+++ b/sale_delivery_date/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import sale_order

--- a/sale_delivery_date/models/sale_order.py
+++ b/sale_delivery_date/models/sale_order.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    delivery_date = fields.Date(string='Delivery date',
+                                default=fields.Date.today())
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    delivery_date = fields.Date(string='Delivery date',
+                                default=fields.Date.today())

--- a/sale_delivery_date/models/sale_order.py
+++ b/sale_delivery_date/models/sale_order.py
@@ -16,7 +16,7 @@
 #
 ##############################################################################
 
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class SaleOrder(models.Model):
@@ -25,9 +25,14 @@ class SaleOrder(models.Model):
     delivery_date = fields.Date(string='Delivery date',
                                 default=fields.Date.today())
 
+    @api.one
+    @api.onchange('delivery_date')
+    def onchange_delivery_date(self):
+        for line in self.order_line:
+            line.delivery_date = self.delivery_date
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    delivery_date = fields.Date(string='Delivery date',
-                                default=fields.Date.today())
+    delivery_date = fields.Date(string='Delivery date')

--- a/sale_delivery_date/views/sale_order_view.xml
+++ b/sale_delivery_date/views/sale_order_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="sale_order_delivery_date_form_view">
+            <field name="name">sale.order.delivery.date.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <field name="date_order" position="after">
+                    <field name="delivery_date" />
+                </field>
+                <field name="order_line" position="attributes">
+                    <attribute name="context">{'default_delivery_date':delivery_date}</attribute>
+                </field>
+                <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
+                    <field name="delivery_date" />
+                </xpath>
+            </field>
+        </record>
+    
+    </data>
+</openerp>


### PR DESCRIPTION
Nuevo modulo:
- añade campo `delivery_date` (fecha de entrega) al pedido de venta
- añade campo fecha de entrega a la línea de pedido de venta (que se inicializa con el valor del pedido de venta)
