### PR TITLE
[MOD] mrp_product_variants

### DIFF
--- a/mrp_product_variants/__openerp__.py
+++ b/mrp_product_variants/__openerp__.py
@@ -23,6 +23,7 @@
         "product",
         "mrp",
         "product_variants_no_automatic_creation",
+        "mrp_production_editable_scheduled_products",
     ],
     "author": "OdooMRP team",
     "contributors": [

--- a/mrp_product_variants/models/mrp.py
+++ b/mrp_product_variants/models/mrp.py
@@ -40,8 +40,8 @@ class MrpBomLine(models.Model):
                                          inverse_name='mrp_bom_line',
                                          string='Product attributes',
                                          copyable=True)
-    attribute_value_ids = fields.Many2many(
-        domain="[('id','in',possible_values[0][2])]")
+#     attribute_value_ids = fields.Many2many(
+#         domain="[('id','in',possible_values[0][2])]")
     possible_values = fields.Many2many(
         comodel_name='product.attribute.value',
         compute='_get_possible_attribute_values')
@@ -82,9 +82,9 @@ class MrpProductionAttribute(models.Model):
     attribute = fields.Many2one(comodel_name='product.attribute',
                                 string='Attribute')
     value = fields.Many2one(comodel_name='product.attribute.value',
-                            string='Value',
-                            domain="[('attribute_id','=',attribute),"
-                            "('id','in',possible_values[0][2])]")
+#                             domain="[('attribute_id','=',attribute),"
+#                             "('id','in',possible_values[0][2])]",
+                            string='Value')
     possible_values = fields.Many2many(
         comodel_name='product.attribute.value',
         compute='_get_possible_attribute_values')
@@ -136,6 +136,9 @@ class MrpProduction(models.Model):
                                            attribute.attribute_id})
             mo.product_attributes = product_attributes
             return {'domain': {'product_id':
+                               [('product_tmpl_id', '=',
+                                 mo.product_template.id)],
+                               'bom_id':
                                [('product_tmpl_id', '=',
                                  mo.product_template.id)]}}
 

--- a/mrp_product_variants/models/mrp.py
+++ b/mrp_product_variants/models/mrp.py
@@ -93,7 +93,8 @@ class MrpProductionAttribute(models.Model):
     @api.depends('mrp_production.product_template')
     def _get_possible_attribute_values(self):
         domain = []
-        for attr_line in self.mrp_production.product_template.attribute_line_ids:
+        for attr_line in (
+                self.mrp_production.product_template.attribute_line_ids):
             for attr_value in attr_line.value_ids:
                 domain.append(attr_value.id)
         self.possible_values = domain

--- a/mrp_product_variants/models/mrp.py
+++ b/mrp_product_variants/models/mrp.py
@@ -40,13 +40,8 @@ class MrpBomLine(models.Model):
                                          inverse_name='mrp_bom_line',
                                          string='Product attributes',
                                          copyable=True)
-<<<<<<< HEAD
 #     attribute_value_ids = fields.Many2many(
 #         domain="[('id','in',possible_values[0][2])]")
-=======
-    attribute_value_ids = fields.Many2many(
-        domain="[('id','in',possible_values[0][2])]")
->>>>>>> 289bafc4979d829ff7db6c1e719d444062ae28ad
     possible_values = fields.Many2many(
         comodel_name='product.attribute.value',
         compute='_get_possible_attribute_values')
@@ -87,15 +82,9 @@ class MrpProductionAttribute(models.Model):
     attribute = fields.Many2one(comodel_name='product.attribute',
                                 string='Attribute')
     value = fields.Many2one(comodel_name='product.attribute.value',
-<<<<<<< HEAD
 #                             domain="[('attribute_id','=',attribute),"
 #                             "('id','in',possible_values[0][2])]",
                             string='Value')
-=======
-                            string='Value',
-                            domain="[('attribute_id','=',attribute),"
-                            "('id','in',possible_values[0][2])]")
->>>>>>> 289bafc4979d829ff7db6c1e719d444062ae28ad
     possible_values = fields.Many2many(
         comodel_name='product.attribute.value',
         compute='_get_possible_attribute_values')

--- a/mrp_product_variants/models/mrp.py
+++ b/mrp_product_variants/models/mrp.py
@@ -33,9 +33,9 @@ class MrpBomAttribute(models.Model):
 class MrpBom(models.Model):
     _inherit = 'mrp.bom'
 
-    possible_values = fields.Many2many(comodel_name='product.attribute.value',
-                                       compute='_get_possible_attribute_values',
-                                       store=True)
+    possible_values = fields.Many2many(
+        comodel_name='product.attribute.value',
+        compute='_get_possible_attribute_values', store=True)
 
     @api.one
     @api.depends('product_tmpl_id')
@@ -57,9 +57,11 @@ class MrpBomLine(models.Model):
                                          inverse_name='mrp_bom_line',
                                          string='Product attributes',
                                          copyable=True)
-    attribute_value_ids = fields.Many2many(domain="[('id','in',possible_values[0][2])]")
-    possible_values = fields.Many2many(comodel_name='product.attribute.value',
-                                       compute='_get_possible_attribute_values')
+    attribute_value_ids = fields.Many2many(
+        domain="[('id','in',possible_values[0][2])]")
+    possible_values = fields.Many2many(
+        comodel_name='product.attribute.value',
+        compute='_get_possible_attribute_values')
 
     @api.one
     @api.depends('bom_id')
@@ -96,11 +98,13 @@ class MrpProductionAttribute(models.Model):
                             string='Value',
                             domain="[('attribute_id','=',attribute),"
                             "('id','in',possible_values[0][2])]")
-    possible_values = fields.Many2many(comodel_name='product.attribute.value',
-                                       compute='_get_possible_attribute_values')
+    possible_values = fields.Many2many(
+        comodel_name='product.attribute.value',
+        compute='_get_possible_attribute_values')
 
     @api.one
-    @api.depends('mrp_production')
+    @api.depends('mrp_production', 'mrp_production.possible_values',
+                 'mrp_production.product_template')
     def _get_possible_attribute_values(self):
         self.possible_values = self.mrp_production.possible_values
 
@@ -117,9 +121,9 @@ class MrpProduction(models.Model):
         comodel_name='mrp.production.attribute', inverse_name='mrp_production',
         string='Product attributes', copyable=True, readonly=True,
         states={'draft': [('readonly', False)]},)
-    possible_values = fields.Many2many(comodel_name='product.attribute.value',
-                                       compute='_get_possible_attribute_values',
-                                       store=True)
+    possible_values = fields.Many2many(
+        comodel_name='product.attribute.value',
+        compute='_get_possible_attribute_values', store=True)
 
     @api.one
     @api.depends('product_template')

--- a/mrp_product_variants/security/ir.model.access.csv
+++ b/mrp_product_variants/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mrp_bom_attribute,mrp_bom_attribute,mrp_product_variants.model_mrp_bom_attribute,mrp.group_mrp_user,1,1,1,1
 access_mrp_production_attribute,mrp_production_attribute,mrp_product_variants.model_mrp_production_attribute,mrp.group_mrp_user,1,1,1,1
+access_mrp_production_product_line_attribute,access_mrp_production_product_line_attribute,model_mrp_production_product_line_attribute,,1,1,1,1

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -10,13 +10,14 @@
                     expr="//field[@name='bom_line_ids']//field[@name='product_id']"
                     position="before">
                     <field name="product_template" />
-<!--                     <field name="possible_values" invisible="1" /> -->
+                    <!-- <field name="possible_values" invisible="1" /> -->
                 </xpath>
                 <xpath
                     expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
                     position="attributes">
-                    <attribute name="options">{'no_create': True}</attribute>
-                    </xpath>
+                    <attribute name="options">{'no_create': True}
+                    </attribute>
+                </xpath>
             </field>
         </record>
 
@@ -69,25 +70,57 @@
                 <field name="product_id" position="before">
                     <field name="product_template" />
                 </field>
-<!--                 <field name="product_id" position="attributes"> -->
-<!--                     <attribute name="invisible">1</attribute> -->
-<!--                 </field> -->
+                <field name="product_id" position="attributes">
+                    <!-- <attribute name="invisible">1</attribute> -->
+                    <attribute name="string">Product Variants
+                    </attribute>
+                </field>
                 <notebook position="before">
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
-                        options="{'no_create': True, 'no_delete': True}" >
-                        <tree create="0" editable="1">
+                        options="{'no_create': True, 'no_delete': True}">
+                        <tree create="0" delete="0" editable="1">
                             <field name="attribute" />
                             <field name="value" options="{'no_create': True}" />
-<!--                             <field name="possible_values" invisible="1" /> -->
+                            <!-- <field name="possible_values" invisible="1" 
+                                /> -->
                         </tree>
                     </field>
                 </notebook>
             </field>
         </record>
 
-        <record model="ir.ui.view" id="mrp_production_product_line_extended_form_view">
-            <field name="name">mrp.production.product.line.extended.form</field>
+        <record model="ir.ui.view" id="mrp.mrp_production_product_form_view">
+            <field name="name">mrp.production.product.line.form</field>
+            <field name="model">mrp.production.product.line</field>
+            <field name="arch" type="xml">
+                <form string="Scheduled Products">
+                    <group col="4">
+                        <field name="name" />
+                        <field name="product_id" />
+                        <label for="product_qty" />
+                        <div>
+                            <field name="product_qty" class="oe_inline" />
+                            <field name="product_uom" groups="product.group_uom"
+                                class="oe_inline" />
+                        </div>
+                        <label for="product_uos_qty" groups="product.group_uos" />
+                        <div groups="product.group_uos">
+                            <field name="product_uos_qty" class="oe_inline" />
+                            <label string="-"
+                                attrs="{'invisible':[('product_uos','=',False)]}"
+                                class="oe_inline" />
+                            <field name="product_uos" class="oe_inline" />
+                        </div>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view"
+            id="mrp_production_product_line_extended_form_view">
+            <field name="name">mrp.production.product.line.extended.form
+            </field>
             <field name="model">mrp.production.product.line</field>
             <field name="inherit_id" ref="mrp.mrp_production_product_form_view" />
             <field name="arch" type="xml">
@@ -97,21 +130,23 @@
                 <field name="product_id" position="attributes">
                     <attribute name="string">Product Variants</attribute>
                 </field>
-                <field name="product_uos" position="after">
+                <xpath expr="//field[@name='product_uos']/.." position="after">
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
-                        options="{'no_create': True, 'no_delete': True}" >
+                        options="{'no_create': True, 'no_delete': True}">
                         <tree create="0" delete="0" editable="1">
                             <field name="attribute" />
                             <field name="value" options="{'no_create': True}" />
                         </tree>
                     </field>
-                </field>
+                </xpath>
             </field>
         </record>
 
-        <record model="ir.ui.view" id="mrp_production_product_line_extended_tree_view">
-            <field name="name">mrp.production.product.line.extended.tree</field>
+        <record model="ir.ui.view"
+            id="mrp_production_product_line_extended_tree_view">
+            <field name="name">mrp.production.product.line.extended.tree
+            </field>
             <field name="model">mrp.production.product.line</field>
             <field name="inherit_id" ref="mrp.mrp_production_product_tree_view" />
             <field name="arch" type="xml">

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -6,18 +6,17 @@
             <field name="model">mrp.bom</field>
             <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
             <field name="arch" type="xml">
-                <field name="bom_line_ids" position="attributes">
-                    <attribute name="context">{'bom_template_id': product_tmpl_id}</attribute>
-                </field>
-                <xpath expr="//field[@name='bom_line_ids']/tree"
-                    position="attributes">
-                    <attribute name="editable" />
-                </xpath>
                 <xpath
                     expr="//field[@name='bom_line_ids']//field[@name='product_id']"
                     position="before">
                     <field name="product_template" />
+                    <field name="possible_values" invisible="1" />
                 </xpath>
+                <xpath
+                    expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
+                    position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                    </xpath>
             </field>
         </record>
 
@@ -54,6 +53,7 @@
                             <field name="routing_id" />
                         </group>
                     </group>
+                    <field name="possible_values" />
                     <label for="attribute_value_ids" />
                     <field name="attribute_value_ids" widget="many2many_tags" />
                     <label for="property_ids" />
@@ -71,12 +71,16 @@
                     <field name="product_template" />
                 </field>
                 <notebook position="before">
+                    <field name="possible_values" invisible="1"/>
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
-                        options="{'no_create': True, 'no_delete': True}">
-                        <tree create="false" editable="1">
+                        options="{'no_create': True, 'no_delete': True}"
+                        context="{'default_mrp_production':id}">
+                        <tree create="0" editable="1">
+                            <field name="mrp_production" />
                             <field name="attribute" />
-                            <field name="value" />
+                            <field name="value" options="{'no_create': True}"/>
+                            <field name="possible_values" invisible="1" />
                         </tree>
                     </field>
                 </notebook>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -71,15 +71,14 @@
                     <field name="product_template" />
                 </field>
                 <notebook position="before">
-                    <field name="possible_values" invisible="1"/>
+                    <field name="possible_values" invisible="1" />
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
                         options="{'no_create': True, 'no_delete': True}"
                         context="{'default_mrp_production':id}">
                         <tree create="0" editable="1">
-                            <field name="mrp_production" />
                             <field name="attribute" />
-                            <field name="value" options="{'no_create': True}"/>
+                            <field name="value" options="{'no_create': True}" />
                             <field name="possible_values" invisible="1" />
                         </tree>
                     </field>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -10,11 +10,7 @@
                     expr="//field[@name='bom_line_ids']//field[@name='product_id']"
                     position="before">
                     <field name="product_template" />
-<<<<<<< HEAD
 <!--                     <field name="possible_values" invisible="1" /> -->
-=======
-                    <field name="possible_values" invisible="1" />
->>>>>>> 289bafc4979d829ff7db6c1e719d444062ae28ad
                 </xpath>
                 <xpath
                     expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
@@ -80,11 +76,7 @@
                         <tree create="0" editable="1">
                             <field name="attribute" />
                             <field name="value" options="{'no_create': True}" />
-<<<<<<< HEAD
 <!--                             <field name="possible_values" invisible="1" /> -->
-=======
-                            <field name="possible_values" invisible="1" />
->>>>>>> 289bafc4979d829ff7db6c1e719d444062ae28ad
                         </tree>
                     </field>
                 </notebook>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -53,7 +53,6 @@
                             <field name="routing_id" />
                         </group>
                     </group>
-                    <field name="possible_values" />
                     <label for="attribute_value_ids" />
                     <field name="attribute_value_ids" widget="many2many_tags" />
                     <label for="property_ids" />
@@ -71,11 +70,9 @@
                     <field name="product_template" />
                 </field>
                 <notebook position="before">
-                    <field name="possible_values" invisible="1" />
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
-                        options="{'no_create': True, 'no_delete': True}"
-                        context="{'default_mrp_production':id}">
+                        options="{'no_create': True, 'no_delete': True}" >
                         <tree create="0" editable="1">
                             <field name="attribute" />
                             <field name="value" options="{'no_create': True}" />

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -69,6 +69,9 @@
                 <field name="product_id" position="before">
                     <field name="product_template" />
                 </field>
+<!--                 <field name="product_id" position="attributes"> -->
+<!--                     <attribute name="invisible">1</attribute> -->
+<!--                 </field> -->
                 <notebook position="before">
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
@@ -80,6 +83,34 @@
                         </tree>
                     </field>
                 </notebook>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="mrp_production_product_line_extended_form_view">
+            <field name="name">mrp.production.product.line.extended.form</field>
+            <field name="model">mrp.production.product.line</field>
+            <field name="inherit_id" ref="mrp.mrp_production_product_form_view" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="before">
+                    <field name="product_template" />
+                </field>
+                <field name="product_id" position="attributes">
+                    <attribute name="string">Product Variants</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="mrp_production_product_line_extended_tree_view">
+            <field name="name">mrp.production.product.line.extended.tree</field>
+            <field name="model">mrp.production.product.line</field>
+            <field name="inherit_id" ref="mrp.mrp_production_product_tree_view" />
+            <field name="arch" type="xml">
+                <field name="product_id" position="before">
+                    <field name="product_template" />
+                </field>
+                <field name="product_id" position="attributes">
+                    <attribute name="string">Product Variants</attribute>
+                </field>
             </field>
         </record>
     </data>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -97,6 +97,16 @@
                 <field name="product_id" position="attributes">
                     <attribute name="string">Product Variants</attribute>
                 </field>
+                <field name="product_uos" position="after">
+                    <field name="product_attributes"
+                        attrs="{'invisible':[('product_attributes','=',[])]}"
+                        options="{'no_create': True, 'no_delete': True}" >
+                        <tree create="0" delete="0" editable="1">
+                            <field name="attribute" />
+                            <field name="value" options="{'no_create': True}" />
+                        </tree>
+                    </field>
+                </field>
             </field>
         </record>
 

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -10,7 +10,7 @@
                     expr="//field[@name='bom_line_ids']//field[@name='product_id']"
                     position="before">
                     <field name="product_template" />
-                    <field name="possible_values" invisible="1" />
+<!--                     <field name="possible_values" invisible="1" /> -->
                 </xpath>
                 <xpath
                     expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
@@ -76,7 +76,7 @@
                         <tree create="0" editable="1">
                             <field name="attribute" />
                             <field name="value" options="{'no_create': True}" />
-                            <field name="possible_values" invisible="1" />
+<!--                             <field name="possible_values" invisible="1" /> -->
                         </tree>
                     </field>
                 </notebook>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -6,15 +6,17 @@
             <field name="model">mrp.bom</field>
             <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='bom_line_ids']/tree"
-                    position="attributes">
-                    <attribute name="editable" />
-                </xpath>
                 <xpath
                     expr="//field[@name='bom_line_ids']//field[@name='product_id']"
                     position="before">
                     <field name="product_template" />
+                    <field name="possible_values" invisible="1" />
                 </xpath>
+                <xpath
+                    expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
+                    position="attributes">
+                    <attribute name="options">{'no_create': True}</attribute>
+                    </xpath>
             </field>
         </record>
 
@@ -70,10 +72,11 @@
                 <notebook position="before">
                     <field name="product_attributes"
                         attrs="{'invisible':[('product_attributes','=',[])]}"
-                        options="{'no_create': True, 'no_delete': True}">
-                        <tree create="false" editable="1">
+                        options="{'no_create': True, 'no_delete': True}" >
+                        <tree create="0" editable="1">
                             <field name="attribute" />
-                            <field name="value" />
+                            <field name="value" options="{'no_create': True}" />
+                            <field name="possible_values" invisible="1" />
                         </tree>
                     </field>
                 </notebook>

--- a/mrp_product_variants/views/mrp_view.xml
+++ b/mrp_product_variants/views/mrp_view.xml
@@ -6,6 +6,9 @@
             <field name="model">mrp.bom</field>
             <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
             <field name="arch" type="xml">
+                <field name="bom_line_ids" position="attributes">
+                    <attribute name="context">{'bom_template_id': product_tmpl_id}</attribute>
+                </field>
                 <xpath expr="//field[@name='bom_line_ids']/tree"
                     position="attributes">
                     <attribute name="editable" />


### PR DESCRIPTION
- Domain en lineas de lista de materiales para que solo se puedan elegir variantes acordes con el producto (plantilla) de la lista.
- Eliminar que la variante de producto sea requerida en la orden de producción.

TODO:
- Hacer editable las líneas de la lista de materiales
- Limitar valores de atributos del configurador en la orden de producción a los configurados en el producto (plantilla)
