### PR TITLE
[FIX mrp_bom_by_percentage]

### DIFF
--- a/mrp_bom_by_percentage/__init__.py
+++ b/mrp_bom_by_percentage/__init__.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from . import models

--- a/mrp_bom_by_percentage/__openerp__.py
+++ b/mrp_bom_by_percentage/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+{
+    "name": "MRP Bom By Percentage",
+    "version": "1.0",
+    "author": "OdooMRP team",
+    "category": "MRP",
+    "website": "http://www.odoomrp.com",
+    "description": """
+    This module performs the following:
+
+    Include in the header of the Bom list, two new fields:
+
+        1.- Produce by percentage: Type boolean, when you check this new field,
+            the quantity to be produced is 100, and the field 'amount to
+            produce' will be invisible.
+
+        2.- QTY to consume. Calculated field. Displays the sum of all amounts
+            to consume.
+
+    If the BoM list is by_percentage, will be validated that the new field
+    'QTY to consume' is not greater than 100.
+    """,
+    "depends": ['mrp',
+                ],
+    "data": ['views/mrp_bom_view.xml',
+             ],
+    "installable": True
+}

--- a/mrp_bom_by_percentage/i18n/es.po
+++ b/mrp_bom_by_percentage/i18n/es.po
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_bom_by_percentage
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-17 10:17+0000\n"
+"PO-Revision-Date: 2014-10-17 12:18+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: mrp_bom_by_percentage
+#: model:ir.model,name:mrp_bom_by_percentage.model_mrp_bom
+msgid "Bill of Material"
+msgstr "Lista de material"
+
+#. module: mrp_bom_by_percentage
+#: field:mrp.bom,by_percentage:0
+msgid "Produce by percentage"
+msgstr "Producir por porcentaje"
+
+#. module: mrp_bom_by_percentage
+#: field:mrp.bom,qty_to_consume:0
+msgid "QTY to consume"
+msgstr "Cantidad a consumir"
+
+#. module: mrp_bom_by_percentage
+#: code:addons/mrp_bom_by_percentage/models/mrp_bom.py:48
+#, python-format
+msgid "Quantity to consume <> 100"
+msgstr "Cantidad a consumir <> 100"
+
+#. module: mrp_bom_by_percentage
+#: view:mrp.bom:mrp_bom_by_percentage.mrp_bom_form_view_inh_withsumqtytoconsume
+msgid "{'invisible': [('by_percentage','=',True)]}"
+msgstr "{'invisible': [('by_percentage','=',True)]}"
+

--- a/mrp_bom_by_percentage/i18n/mrp_bom_by_percentage.pot
+++ b/mrp_bom_by_percentage/i18n/mrp_bom_by_percentage.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_bom_by_percentage
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-10-17 10:17+0000\n"
+"PO-Revision-Date: 2014-10-17 10:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_bom_by_percentage
+#: model:ir.model,name:mrp_bom_by_percentage.model_mrp_bom
+msgid "Bill of Material"
+msgstr ""
+
+#. module: mrp_bom_by_percentage
+#: field:mrp.bom,by_percentage:0
+msgid "Produce by percentage"
+msgstr ""
+
+#. module: mrp_bom_by_percentage
+#: field:mrp.bom,qty_to_consume:0
+msgid "QTY to consume"
+msgstr ""
+
+#. module: mrp_bom_by_percentage
+#: code:addons/mrp_bom_by_percentage/models/mrp_bom.py:48
+#, python-format
+msgid "Quantity to consume <> 100"
+msgstr ""
+
+#. module: mrp_bom_by_percentage
+#: view:mrp.bom:mrp_bom_by_percentage.mrp_bom_form_view_inh_withsumqtytoconsume
+msgid "{'invisible': [('by_percentage','=',True)]}"
+msgstr ""
+

--- a/mrp_bom_by_percentage/models/__init__.py
+++ b/mrp_bom_by_percentage/models/__init__.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from . import mrp_bom

--- a/mrp_bom_by_percentage/models/mrp_bom.py
+++ b/mrp_bom_by_percentage/models/mrp_bom.py
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+from openerp import models, fields, api, exceptions, _
+import openerp.addons.decimal_precision as dp
+
+
+class MrpBom(models.Model):
+    _inherit = 'mrp.bom'
+
+    @api.one
+    @api.depends('bom_line_ids')
+    def _compute_qtytoconsume(self):
+        qty_to_consume = 0
+        if self.bom_line_ids:
+            for line in self.bom_line_ids:
+                qty_to_consume += line.product_qty
+        self.qty_to_consume = qty_to_consume
+
+    by_percentage = fields.Boolean(string='Produce by percentage')
+    qty_to_consume = fields.Float(
+        string='QTY to consume', compute='_compute_qtytoconsume', store=True,
+        digits=dp.get_precision('Product Unit of Measure'))
+
+    @api.onchange('by_percentage')
+    def onchange_by_percentage(self):
+        if self.by_percentage:
+            self.product_qty = 100
+
+    @api.one
+    @api.constrains('by_percentage', 'qty_to_consume', 'bom_line_ids')
+    def _check_by_percentage(self):
+        if self.by_percentage and self.qty_to_consume != 100:
+            raise exceptions.Warning(_('Quantity to consume <> 100'))

--- a/mrp_bom_by_percentage/views/mrp_bom_view.xml
+++ b/mrp_bom_by_percentage/views/mrp_bom_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="mrp_bom_form_view_inh_withsumqtytoconsume" model="ir.ui.view">
+            <field name="name">mrp.bom.form.view.inh.withsumqtytoconsume</field>
+            <field name="model">mrp.bom</field>
+            <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr='//field[@name="routing_id"]/..' position="after">
+                    <field name="qty_to_consume" />
+                </xpath>
+                 <xpath expr='/form/group/group//field[@name="type"]' position="replace">
+                    <group colspan="2" col="4">
+                        <field name="type" />
+                        <field name="by_percentage" />
+                    </group>
+                 </xpath>
+                 <xpath expr='/form/group/group//field[@name="product_qty"]' position="attributes">
+                    <attribute name="attrs">{'invisible': [('by_percentage','=',True)]}</attribute>
+                 </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Ana me ha puesto lo siguiente:

La primera vez que se graba el bom, no deja guardar aunque la suma sea del 100%. Si se desactiva el check, se guarda y se cambian cantidades sí que hace bien la comprobación y permite grabar bien, aunque el check esté clickado. El problema de guardar sólo da si el bom es nuevo
El mensaje tendría que ser <> 100 y no >100, ya que el error es tanto si es mayor de 100 como si es menor de 100.

Bueno.. el caso es que yo creo un lista de materiales nueva, activo el check para que calcule por porcentaje, meto una lína a consumir con 100 de cantidad, y me lo graba perfectamente sin darme ningún error. Solo he cambiado el mensaje del error. No sé si será porque no está actualizado el entorno con los últimos módulos, no se me ocurre porque se comporta de diferente manera en mi local, y en el entorno en el que esta haciendo las pruebas Ana. He subido el módulo.
