### PR TITLE
[IMP quality_control_samples]

### DIFF
--- a/quality_control_samples/views/qc_test_view.xml
+++ b/quality_control_samples/views/qc_test_view.xml
@@ -88,10 +88,10 @@
             <field name="type">form</field>
             <field name="inherit_id" ref="quality_control.qc_test_form_view" />
             <field name="arch" type="xml">
-                <field name="state" position="before">
+                <button name="draft" position="before">
                     <button name="button_create_test_lines" type="object"
                         states="draft" string="Create Lines" />
-                </field>
+                </button>
                 <xpath expr="//field[@name='test_template_id']/.."
                     position="after">
                     <group>


### PR DESCRIPTION
Se ha modificado el formulario de test, para que aparezca el botón de crear líneas, antes de los botones del workflow. Ana me había solicitado que metiese este botón, pero ya lo tenía el módulo, solo se pueden meter líneas de test con este botón, cuando el estado del test sea borrador.
