### PR TITLE
[IMP mrp_wizard_filter_task]

### DIFF
--- a/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task.py
+++ b/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task.py
@@ -29,7 +29,7 @@ class WizardFilterMrpTask(models.TransientModel):
     user = fields.Many2one("res.users", string="User")
 
     def onchange_mrp_production(self, cr, uid, ids, production_id,
-                               context=None):
+                                context=None):
         production_obj = self.pool['mrp.production']
         wc_ids = []
         if production_id:

--- a/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task.py
+++ b/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task.py
@@ -28,6 +28,21 @@ class WizardFilterMrpTask(models.TransientModel):
         "mrp.production.workcenter.line", string="Work Order")
     user = fields.Many2one("res.users", string="User")
 
+    def onchange_mrp_production(self, cr, uid, ids, production_id,
+                               context=None):
+        production_obj = self.pool['mrp.production']
+        wc_ids = []
+        if production_id:
+            production = production_obj.browse(cr, uid, production_id,
+                                               context=context)
+            for wc_line in production.workcenter_lines:
+                wc_ids.append(wc_line.id)
+        if wc_ids:
+            domain_wk_order = [('id', 'in', wc_ids)]
+            return {'domain': {'wk_order': domain_wk_order}}
+        else:
+            return {'domain': {'wk_order': False}}
+
     def mrp_task_open_window(self, cr, uid, ids, context=None):
         mod_obj = self.pool['ir.model.data']
         act_obj = self.pool['ir.actions.act_window']
@@ -49,8 +64,8 @@ class WizardFilterMrpTask(models.TransientModel):
             domain.append(('wk_order', '=', data.wk_order.id))
             result_context.update({'wk_order': data.wk_order.id})
         if data.user:
-            domain.append(('user', '=', data.user.id))
-            result_context.update({'user': data.user.id})
+            domain.append(('user_id', '=', data.user.id))
+            result_context.update({'user_id': data.user.id})
         result['domain'] = domain
         result['context'] = str(result_context)
         return result

--- a/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task_view.xml
+++ b/mrp_wizard_filter_task/wizard/wizard_filter_mrp_task_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Wizard filter MRP task">
                     <group string="Production">
-                        <field name="mrp_production" />
+                        <field name="mrp_production" on_change="onchange_mrp_production(mrp_production)"/>
                     </group>
                     <group string="Work Order">
                         <field name="wk_order" />


### PR DESCRIPTION
1 modificación, y un arreglo de BUG reportado por Ana, se ha subido el módulo, para modificar/corregir lo siguiente:

```
El combo de operaciones debería filtrar de base, las operaciones de la of que se han seleccionado en el primer combo.

Al pulsar confirmar da este traceback
File "/opt/odoo/v8/core/openerp/api.py", line 237, in wrapper
return old_api(self, *args, **kwargs)
File "/opt/odoo/v8/core/openerp/models.py", line 1674, in search
return self.search(cr, user, args, offset=offset, limit=limit, order=order, context=context, count=count)
File "/opt/odoo/v8/core/openerp/api.py", line 237, in wrapper
return old_api(self, *args, **kwargs)
File "/opt/odoo/v8/core/openerp/models.py", line 4523, in search
query = self._where_calc(cr, user, args, context=context)
File "/opt/odoo/v8/core/openerp/api.py", line 237, in wrapper
return old_api(self, *args, **kwargs)
File "/opt/odoo/v8/core/openerp/models.py", line 4346, in _where_calc
e = expression.expression(cr, user, domain, self, context)
File "/opt/odoo/v8/core/openerp/osv/expression.py", line 646, in __init
self.parse(cr, uid, context=context)
File "/opt/odoo/v8/core/openerp/osv/expression.py", line 812, in parse
raise ValueError("Invalid field %r in leaf %r" % (left, str(leaf)))
ValueError: Invalid field 'user' in leaf ""
```
