### PR TITLE
[FIX mrp_bom_version]

### DIFF
--- a/mrp_bom_version/__openerp__.py
+++ b/mrp_bom_version/__openerp__.py
@@ -24,12 +24,10 @@
     "description": """
     This module performs the following:
 
-    1.- In the MRP BoM list object, 3 new fields are added:
+    1.- In the MRP BoM list object, 2 new fields are added:
 
-        1.1.- Review, of type integer, defined by hand. When saving the list
-              verified that there is another with the same sequence.
-        1.2.- Historical Date, of type date.
-        1.3.- Status, of type selection, with these values: draft, in active
+        1.1.- Historical Date, of type date.
+        1.2.- Status, of type selection, with these values: draft, in active
               and historical. This new field has gotten because it has added a
               workflow to MRP BoM list object.
 
@@ -38,6 +36,7 @@
     historical state.
     when the MRP BoM list is put to active, a record of who has activated,
     and when will include in chatter/log.
+    Also creates a constraint for the sequence field to be unique.
     """,
     "depends": ['mrp',
                 ],

--- a/mrp_bom_version/i18n/es.po
+++ b/mrp_bom_version/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 14:36+0000\n"
-"PO-Revision-Date: 2014-10-23 16:40+0100\n"
+"POT-Creation-Date: 2014-11-10 09:13+0000\n"
+"PO-Revision-Date: 2014-11-10 10:14+0100\n"
 "Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -48,6 +48,12 @@ msgid "In active"
 msgstr "En activo"
 
 #. module: mrp_bom_version
+#: model:mail.message.subtype,description:mrp_bom_version.mt_active
+#: model:mail.message.subtype,name:mrp_bom_version.mt_active
+msgid "MRP BoM Active"
+msgstr "MRP BoM Active"
+
+#. module: mrp_bom_version
 #: view:mrp.bom:mrp_bom_version.mrp_bom_tree_view
 msgid "MRP BoMs"
 msgstr "MRP LdMs"
@@ -63,11 +69,6 @@ msgid "Product"
 msgstr "Producto"
 
 #. module: mrp_bom_version
-#: field:mrp.bom,review:0
-msgid "Review"
-msgstr "Revisión"
-
-#. module: mrp_bom_version
 #: view:mrp.bom:mrp_bom_version.view_mrp_bom_filter_inh_version
 msgid "State"
 msgstr "Estado"
@@ -78,10 +79,10 @@ msgid "Status"
 msgstr "Estatus"
 
 #. module: mrp_bom_version
-#: code:addons/mrp_bom_version/models/mrp.py:49
+#: code:addons/mrp_bom_version/models/mrp.py:53
 #, python-format
-msgid "The version number must be unique"
-msgstr "El número de versión debe ser única"
+msgid "The sequence must be unique"
+msgstr "La secuencia debe ser única."
 
 #. module: mrp_bom_version
 #: view:mrp.bom:mrp_bom_version.mrp_bom_form_view_inh_version

--- a/mrp_bom_version/i18n/mrp_bom_version.pot
+++ b/mrp_bom_version/i18n/mrp_bom_version.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-10-23 14:35+0000\n"
-"PO-Revision-Date: 2014-10-23 14:35+0000\n"
+"POT-Creation-Date: 2014-11-10 09:13+0000\n"
+"PO-Revision-Date: 2014-11-10 09:13+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -48,6 +48,12 @@ msgid "In active"
 msgstr ""
 
 #. module: mrp_bom_version
+#: model:mail.message.subtype,description:mrp_bom_version.mt_active
+#: model:mail.message.subtype,name:mrp_bom_version.mt_active
+msgid "MRP BoM Active"
+msgstr ""
+
+#. module: mrp_bom_version
 #: view:mrp.bom:mrp_bom_version.mrp_bom_tree_view
 msgid "MRP BoMs"
 msgstr ""
@@ -63,11 +69,6 @@ msgid "Product"
 msgstr ""
 
 #. module: mrp_bom_version
-#: field:mrp.bom,review:0
-msgid "Review"
-msgstr ""
-
-#. module: mrp_bom_version
 #: view:mrp.bom:mrp_bom_version.view_mrp_bom_filter_inh_version
 msgid "State"
 msgstr ""
@@ -78,9 +79,9 @@ msgid "Status"
 msgstr ""
 
 #. module: mrp_bom_version
-#: code:addons/mrp_bom_version/models/mrp.py:49
+#: code:addons/mrp_bom_version/models/mrp.py:53
 #, python-format
-msgid "The version number must be unique"
+msgid "The sequence must be unique"
 msgstr ""
 
 #. module: mrp_bom_version

--- a/mrp_bom_version/views/mrp_bom_view.xml
+++ b/mrp_bom_version/views/mrp_bom_view.xml
@@ -8,7 +8,7 @@
                 <tree string="MRP BoMs">
                     <field name="name"/>
                     <field name="active" />
-                    <field name="review" />
+                    <field name="sequence" />
                     <field name="state" />
                     <field name="historical_date"/>
                 </tree>
@@ -28,8 +28,7 @@
                     </header>
                 </xpath>
                 <field name="company_id" position="after">
-                    <group colspan="2" col="4">
-                        <field name="review" attrs="{'readonly':[('state', '=', 'historical')]}" />
+                    <group colspan="2" >
                         <field name="historical_date" />
                     </group>
                 </field>


### PR DESCRIPTION
A petición de Ana, se ha quitado el campo "review", y se ha utilizado el campo "sequence", que ya existía en el objeto "mrp.bom".
Se ha corregido también el BUG al duplicar la lista de materiales, a la nueva lista de material resultante, se le pone automáticamente el número de secuencia que le corresponde.
