### PR TITLE
[NEW mrp_routing_workcenter]

### DIFF
--- a/mrp_routing_workcenter/__init__.py
+++ b/mrp_routing_workcenter/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/mrp_routing_workcenter/__init__.py
+++ b/mrp_routing_workcenter/__init__.py
@@ -15,5 +15,4 @@
 #    along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-
 from . import models

--- a/mrp_routing_workcenter/__openerp__.py
+++ b/mrp_routing_workcenter/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+{
+    "name": "MRP Routing Workcenter",
+    "version": "1.0",
+    "author": "OdooMRP team",
+    "contributors": [
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    "category": "Manufacturing",
+    "website": "http://www.odoomrp.com",
+    "description": """
+    This module performs the following:
+
+    1.- In object 'mrp.routing", create the new field Work Center.
+
+    2.- In object 'mrp.workcenter", create the new field 'Capacity per cicle
+        min'. Also puts the 'Capacity per cycle maximum.' descrition to the
+        'capacity_per_cycle' field.
+    3.- When the routing is selected in MRP Production, the maximum capacity
+        of the cycle is put automatically into the amount to produce.
+
+    When the quantity to be produced is changed, and this is < or > than the
+    capacity per cicle, minimun or maximun, one warning of this fact is shown.
+    """,
+    "depends": ['mrp',
+                ],
+    "data": ['views/mrp_view.xml',
+             ],
+    "installable": True
+}

--- a/mrp_routing_workcenter/i18n/es.po
+++ b/mrp_routing_workcenter/i18n/es.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_routing_workcenter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-11 11:08+0000\n"
+"PO-Revision-Date: 2014-11-11 12:09+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: mrp_routing_workcenter
+#: field:mrp.workcenter,capacity_per_cycle_min:0
+msgid "Capacity per Cycle Min."
+msgstr "Capacidad por ciclo mínima."
+
+#. module: mrp_routing_workcenter
+#: help:mrp.workcenter,capacity_per_cycle_min:0
+msgid "Capacity per cycle minimum."
+msgstr "Capacidad por ciclo máxima"
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Órden de producción"
+
+#. module: mrp_routing_workcenter
+#: code:addons/mrp_routing_workcenter/models/mrp.py:65
+#, python-format
+msgid "Product QTY < Capacity per cycle minimun, or > Capacity per cycle maximun"
+msgstr "Cantidad producto < capacidad mínima por ciclo, o > capacidad máxima por ciclo"
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_routing
+msgid "Routing"
+msgstr "Proceso productivo"
+
+#. module: mrp_routing_workcenter
+#: code:addons/mrp_routing_workcenter/models/mrp.py:64
+#, python-format
+msgid "Warning!"
+msgstr "Atención!"
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_workcenter
+msgid "Work Center"
+msgstr "Centro de producción"
+
+#. module: mrp_routing_workcenter
+#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
+msgid "[('id', 'in', allowed_routings[0][2])]"
+msgstr "[('id', 'in', allowed_routings[0][2])]"
+
+#. module: mrp_routing_workcenter
+#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
+msgid "product_qty_change_mrp_production(product_qty, routing_id)"
+msgstr "product_qty_change_mrp_production(product_qty, routing_id)"
+

--- a/mrp_routing_workcenter/i18n/es.po
+++ b/mrp_routing_workcenter/i18n/es.po
@@ -6,13 +6,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-11 11:08+0000\n"
-"PO-Revision-Date: 2014-11-11 12:09+0100\n"
-"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"POT-Creation-Date: 2014-11-13 08:31+0000\n"
+"PO-Revision-Date: 2014-11-13 08:31+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: mrp_routing_workcenter
@@ -31,7 +31,7 @@ msgid "Manufacturing Order"
 msgstr "Órden de producción"
 
 #. module: mrp_routing_workcenter
-#: code:addons/mrp_routing_workcenter/models/mrp.py:65
+#: code:addons/mrp_routing_workcenter/models/mrp.py:37
 #, python-format
 msgid "Product QTY < Capacity per cycle minimun, or > Capacity per cycle maximun"
 msgstr "Cantidad producto < capacidad mínima por ciclo, o > capacidad máxima por ciclo"
@@ -42,20 +42,16 @@ msgid "Routing"
 msgstr "Proceso productivo"
 
 #. module: mrp_routing_workcenter
-#: code:addons/mrp_routing_workcenter/models/mrp.py:64
+#: code:addons/mrp_routing_workcenter/models/mrp.py:36
 #, python-format
 msgid "Warning!"
 msgstr "Atención!"
 
 #. module: mrp_routing_workcenter
 #: model:ir.model,name:mrp_routing_workcenter.model_mrp_workcenter
+#: field:mrp.routing,workcenter:0
 msgid "Work Center"
 msgstr "Centro de producción"
-
-#. module: mrp_routing_workcenter
-#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
-msgid "[('id', 'in', allowed_routings[0][2])]"
-msgstr "[('id', 'in', allowed_routings[0][2])]"
 
 #. module: mrp_routing_workcenter
 #: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter

--- a/mrp_routing_workcenter/i18n/mrp_routing_workcenter.pot
+++ b/mrp_routing_workcenter/i18n/mrp_routing_workcenter.pot
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_routing_workcenter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-11 11:07+0000\n"
+"PO-Revision-Date: 2014-11-11 11:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_routing_workcenter
+#: field:mrp.workcenter,capacity_per_cycle_min:0
+msgid "Capacity per Cycle Min."
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: help:mrp.workcenter,capacity_per_cycle_min:0
+msgid "Capacity per cycle minimum."
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: code:addons/mrp_routing_workcenter/models/mrp.py:65
+#, python-format
+msgid "Product QTY < Capacity per cycle minimun, or > Capacity per cycle maximun"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_routing
+msgid "Routing"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: code:addons/mrp_routing_workcenter/models/mrp.py:64
+#, python-format
+msgid "Warning!"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: model:ir.model,name:mrp_routing_workcenter.model_mrp_workcenter
+msgid "Work Center"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
+msgid "[('id', 'in', allowed_routings[0][2])]"
+msgstr ""
+
+#. module: mrp_routing_workcenter
+#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
+msgid "product_qty_change_mrp_production(product_qty, routing_id)"
+msgstr ""
+

--- a/mrp_routing_workcenter/i18n/mrp_routing_workcenter.pot
+++ b/mrp_routing_workcenter/i18n/mrp_routing_workcenter.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-11 11:07+0000\n"
-"PO-Revision-Date: 2014-11-11 11:07+0000\n"
+"POT-Creation-Date: 2014-11-13 08:30+0000\n"
+"PO-Revision-Date: 2014-11-13 08:30+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,7 +31,7 @@ msgid "Manufacturing Order"
 msgstr ""
 
 #. module: mrp_routing_workcenter
-#: code:addons/mrp_routing_workcenter/models/mrp.py:65
+#: code:addons/mrp_routing_workcenter/models/mrp.py:37
 #, python-format
 msgid "Product QTY < Capacity per cycle minimun, or > Capacity per cycle maximun"
 msgstr ""
@@ -42,19 +42,15 @@ msgid "Routing"
 msgstr ""
 
 #. module: mrp_routing_workcenter
-#: code:addons/mrp_routing_workcenter/models/mrp.py:64
+#: code:addons/mrp_routing_workcenter/models/mrp.py:36
 #, python-format
 msgid "Warning!"
 msgstr ""
 
 #. module: mrp_routing_workcenter
 #: model:ir.model,name:mrp_routing_workcenter.model_mrp_workcenter
+#: field:mrp.routing,workcenter:0
 msgid "Work Center"
-msgstr ""
-
-#. module: mrp_routing_workcenter
-#: view:mrp.production:mrp_routing_workcenter.mrp_production_form_view_inh_mrproutingworkcenter
-msgid "[('id', 'in', allowed_routings[0][2])]"
 msgstr ""
 
 #. module: mrp_routing_workcenter

--- a/mrp_routing_workcenter/models/__init__.py
+++ b/mrp_routing_workcenter/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import mrp

--- a/mrp_routing_workcenter/models/mrp.py
+++ b/mrp_routing_workcenter/models/mrp.py
@@ -39,16 +39,16 @@ class MrpProduction(models.Model):
 
     @api.one
     @api.depends('bom_id', 'bom_id.routing_ids')
-    def _compute_allowed_routings(self):
+    def _compute_permited_routings(self):
         lines = self.env['mrp.routing']
-        self.allowed_routings = lines
+        self.permited_routings = lines
         for routing in self.bom_id.routing_ids:
             lines |= routing
-        self.allowed_routings = lines
+        self.permited_routings = lines
 
-    allowed_routings = fields.Many2many(
+    permited_routings = fields.Many2many(
         'mrp.routing', string='Permited Routings',
-        compute='_compute_allowed_routings')
+        compute='_compute_permited_routings')
 
     @api.multi
     def product_qty_change_mrp_production(self, product_qty=0,

--- a/mrp_routing_workcenter/models/mrp.py
+++ b/mrp_routing_workcenter/models/mrp.py
@@ -1,0 +1,75 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+
+
+class MrpRouting(models.Model):
+    _inherit = 'mrp.routing'
+
+    workcenter = fields.Many2one('mrp.workcenter', string='Work Center')
+
+
+class MrpWorkcenter(models.Model):
+    _inherit = 'mrp.workcenter'
+
+    capacity_per_cycle = fields.Float(
+        string='Capacity per Cycle Max.', help='Capacity per cycle maximum.')
+    capacity_per_cycle_min = fields.Float(
+        string='Capacity per Cycle Min.', help='Capacity per cycle minimum.')
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.one
+    @api.depends('bom_id', 'bom_id.routing_ids')
+    def _compute_allowed_routings(self):
+        lines = self.env['mrp.routing']
+        self.allowed_routings = lines
+        if self.bom_id and self.bom_id.routing_ids:
+            for routing in self.bom_id.routing_ids:
+                lines += routing
+            self.allowed_routings = lines
+
+    allowed_routings = fields.Many2many(
+        'mrp.routing', string='Permited Routings',
+        compute='_compute_allowed_routings')
+
+    def product_qty_change_mrp_production(self, cr, uid, ids, product_qty=0,
+                                          routing_id=False, context=None):
+        result = {}
+        result['value'] = {}
+        routing_obj = self.pool['mrp.routing']
+        if product_qty and routing_id:
+            routing = routing_obj.browse(cr, uid, routing_id, context=context)
+            if (product_qty < routing.workcenter.capacity_per_cycle_min or
+                    product_qty > routing.workcenter.capacity_per_cycle):
+                warning = {
+                    'title': _('Warning!'),
+                    'message': _('Product QTY < Capacity per cycle minimun, or'
+                                 ' > Capacity per cycle maximun'),
+                }
+                result['warning'] = warning
+        return result
+
+    @api.one
+    @api.onchange('routing_id')
+    def onchange_routing(self):
+        if self.routing_id:
+            self.product_qty = self.routing_id.workcenter.capacity_per_cycle

--- a/mrp_routing_workcenter/models/mrp.py
+++ b/mrp_routing_workcenter/models/mrp.py
@@ -19,36 +19,8 @@
 from openerp import models, fields, api, _
 
 
-class MrpRouting(models.Model):
-    _inherit = 'mrp.routing'
-
-    workcenter = fields.Many2one('mrp.workcenter', string='Work Center')
-
-
-class MrpWorkcenter(models.Model):
-    _inherit = 'mrp.workcenter'
-
-    capacity_per_cycle = fields.Float(
-        string='Capacity per Cycle Max.', help='Capacity per cycle maximum.')
-    capacity_per_cycle_min = fields.Float(
-        string='Capacity per Cycle Min.', help='Capacity per cycle minimum.')
-
-
 class MrpProduction(models.Model):
     _inherit = 'mrp.production'
-
-    @api.one
-    @api.depends('bom_id', 'bom_id.routing_ids')
-    def _compute_permited_routings(self):
-        lines = self.env['mrp.routing']
-        self.permited_routings = lines
-        for routing in self.bom_id.routing_ids:
-            lines |= routing
-        self.permited_routings = lines
-
-    permited_routings = fields.Many2many(
-        'mrp.routing', string='Permited Routings',
-        compute='_compute_permited_routings')
 
     @api.multi
     def product_qty_change_mrp_production(self, product_qty=0,
@@ -73,3 +45,18 @@ class MrpProduction(models.Model):
     def onchange_routing(self):
         if self.routing_id:
             self.product_qty = self.routing_id.workcenter.capacity_per_cycle
+
+
+class MrpRouting(models.Model):
+    _inherit = 'mrp.routing'
+
+    workcenter = fields.Many2one('mrp.workcenter', string='Work Center')
+
+
+class MrpWorkcenter(models.Model):
+    _inherit = 'mrp.workcenter'
+
+    capacity_per_cycle = fields.Float(
+        string='Capacity per Cycle Max.', help='Capacity per cycle maximum.')
+    capacity_per_cycle_min = fields.Float(
+        string='Capacity per Cycle Min.', help='Capacity per cycle minimum.')

--- a/mrp_routing_workcenter/views/mrp_view.xml
+++ b/mrp_routing_workcenter/views/mrp_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="mrp_routing_form_view_inh_mrproutingworkcenter">
+            <field name="name">mrp.routing.form.view.inh.rproutingworkcenter</field>
+            <field name="model">mrp.routing</field>
+            <field name="inherit_id" ref="mrp.mrp_routing_form_view" />
+            <field name="arch" type="xml">
+                <field name="name" position="after">
+                    <field name="workcenter" required="1" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="mrp_workcenter_view_inh_mrproutingworkcenter">
+            <field name="name">mrp.workcenter.view.inh.rproutingworkcenter</field>
+            <field name="model">mrp.workcenter</field>
+            <field name="inherit_id" ref="mrp.mrp_workcenter_view" />
+            <field name="arch" type="xml">
+                <field name="capacity_per_cycle" position="before">
+                    <field name="capacity_per_cycle" />
+                </field>
+            </field>
+        </record>
+        <record id="mrp_production_form_view_inh_mrproutingworkcenter" model="ir.ui.view">
+            <field name="name">mrp.production.form.view.inh.mrproutingworkcenter</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+            <field name="arch" type="xml">
+                <field name="product_qty" position="attributes">
+                    <attribute name="on_change">product_qty_change_mrp_production(product_qty, routing_id)</attribute>
+                </field>
+                <field name="origin" position="after">
+                    <field name="allowed_routings" invisible="1"/>
+                </field>
+                <field name="routing_id" position="attributes">
+                    <attribute name="domain">[('id', 'in', allowed_routings[0][2])]</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/mrp_routing_workcenter/views/mrp_view.xml
+++ b/mrp_routing_workcenter/views/mrp_view.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
+
         <record model="ir.ui.view" id="mrp_routing_form_view_inh_mrproutingworkcenter">
             <field name="name">mrp.routing.form.view.inh.rproutingworkcenter</field>
             <field name="model">mrp.routing</field>
@@ -28,12 +29,6 @@
             <field name="arch" type="xml">
                 <field name="product_qty" position="attributes">
                     <attribute name="on_change">product_qty_change_mrp_production(product_qty, routing_id)</attribute>
-                </field>
-                <field name="origin" position="after">
-                    <field name="permited_routings" invisible="1"/>
-                </field>
-                <field name="routing_id" position="attributes">
-                    <attribute name="domain">[('id', 'in', permited_routings[0][2])]</attribute>
                 </field>
             </field>
         </record>

--- a/mrp_routing_workcenter/views/mrp_view.xml
+++ b/mrp_routing_workcenter/views/mrp_view.xml
@@ -30,10 +30,10 @@
                     <attribute name="on_change">product_qty_change_mrp_production(product_qty, routing_id)</attribute>
                 </field>
                 <field name="origin" position="after">
-                    <field name="allowed_routings" invisible="1"/>
+                    <field name="permited_routings" invisible="1"/>
                 </field>
                 <field name="routing_id" position="attributes">
-                    <attribute name="domain">[('id', 'in', allowed_routings[0][2])]</attribute>
+                    <attribute name="domain">[('id', 'in', permited_routings[0][2])]</attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
DESA4. Cantidad a fabricar por defecto según capacidad cuba 

En la ruta se pueda especificar un límite mínimo y máximo en la cantidad para el lanzamiento de las ofs, que precisamente viene marcado por la capacidad de la máquina preferente,

Creo que lo suyo sería:
1. Sacar de recipes el añadir el many2one a la máquina en la ruta.
2. Crear un nuevo módulo que haga:
El mencionado link a workcenter desde ruta
Añadir el campo mínima capacidad (ahora mismo solo tenemos máxima capacidad por ciclo en los workcenters) 
3. Incorporar el onchange que ya está en alm, donde al asignar la ruta en una OF, pone la cantidad máxima de la máquina. 
4. Modificar el warning (actualmente solo avisa si la cantidad supera el máximo de la máquina, pero habría que comprobar que la cantidad está entre el mínimo y el máximo de la máquina) 
