### PR TITLE
[MOD] <product_variants_no_automatic_creation>

### DIFF
--- a/product_variants_no_automatic_creation/models/product.py
+++ b/product_variants_no_automatic_creation/models/product.py
@@ -55,6 +55,22 @@ class ProductTemplate(models.Model):
             else:
                 return True
 
+    @api.multi
+    def action_open_attribute_prices(self):
+        price_obj = self.env['product.attribute.price']
+        for line in self.attribute_line_ids:
+            for value in line.value_ids:
+                prices = price_obj.search([('product_tmpl_id', '=', self.id),
+                                           ('value_id', '=', value.id)])
+                if not prices:
+                    price_obj.create({
+                        'product_tmpl_id': self.id,
+                        'value_id': value.id,
+                    })
+        result = self._get_act_window_dict(
+            'product_variants_no_automatic_creation.attribute_price_action')
+        return result
+
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
@@ -85,3 +101,10 @@ class ProductProduct(models.Model):
                                    value_id))
             return self.search(domain, limit=1) or False
         return False
+
+
+class ProductAttributePrice(models.Model):
+    _inherit = 'product.attribute.price'
+
+    attribute = fields.Many2one(comodel_name='product.attribute',
+                                related='value_id.attribute_id')

--- a/product_variants_no_automatic_creation/views/product_view.xml
+++ b/product_variants_no_automatic_creation/views/product_view.xml
@@ -17,12 +17,43 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_only_form_view" />
             <field name="arch" type="xml">
+                <button string="Variant Prices" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </button>
+                <button string="Variant Prices" position="after">
+                    <button class="oe_inline oe_stat_button" name="action_open_attribute_prices"
+                        icon="fa-strikethrough" type="object" string="Variant Prices">
+                    </button>
+                </button>
                 <field name="attribute_line_ids" position="before">
                     <group>
                         <field name="no_create_variants" />
                     </group>
                 </field>
             </field>
+        </record>
+
+        <record model="ir.ui.view" id="attribute_price_tree_view">
+            <field name="name">product.attribute.price.tree</field>
+            <field name="model">product.attribute.price</field>
+            <field name="arch" type="xml">
+                <tree string="Variant Values">
+                    <field name="attribute" />
+                    <field name="value_id" />
+                    <field name="price_extra" />
+                </tree>
+            </field>
+        </record>
+
+        <record id="attribute_price_action" model="ir.actions.act_window">
+            <field name="name">Variant Values</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">product.attribute.price</field>
+            <field name="view_mode">tree</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="attribute_price_tree_view"/> 
+            <field name="domain">[('product_tmpl_id', '=', active_id)]</field>
+            <field name="context">{'default_product_tmpl_id': active_id}</field>
         </record>
     </data>
 </openerp>


### PR DESCRIPTION
Relacionado con el PR #306 
- Ahora se crearían los precios si entramos en el listado de precios de variantes, para aquellos que no existan (se supone que cuando hay variante `product.product` los crea)
- Se oculta el otro botón para evitar confusiones ya que la vista es similar.
