### PR TITLE
[ADD] <sale_order_line_dates> extending standar <sale_order_dates>

### DIFF
--- a/sale_order_line_dates/__init__.py
+++ b/sale_order_line_dates/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/sale_order_line_dates/__openerp__.py
+++ b/sale_order_line_dates/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Dates on Sales Order",
+    "version": "1.0",
+    "depends": [
+        "sale_order_dates",
+    ],
+    "author": "OdooMRP team",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+    ],
+    "category": "Sales Management",
+    "website": "http://www.odoomrp.com",
+    "summary": "",
+    "description": """
+Add additional date information to the sales order.
+===================================================
+You can add the following additional dates to a sales order lines:
+------------------------------------------------------------------
+    * Requested Date
+    """,
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_line_dates/models/__init__.py
+++ b/sale_order_line_dates/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import sale_order

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -28,7 +28,7 @@ class SaleOrder(models.Model):
         self.ensure_one()
         result = super(SaleOrder, self).onchange_requested_date(
             requested_date, commitment_date)
-        if not 'warning' in result:
+        if 'warning' not in result:
             lines = []
             for line in self.order_line:
                 lines.append((1, line.id, {'requested_date': requested_date}))

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -22,7 +22,18 @@ from openerp import models, fields, api
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    
+    @api.multi
+    def onchange_requested_date(self, requested_date, commitment_date):
+        """Warn if the requested dates is sooner than the commitment date"""
+        self.ensure_one()
+        result = super(SaleOrder, self).onchange_requested_date(
+            requested_date, commitment_date)
+        if not 'warning' in result:
+            lines = []
+            for line in self.order_line:
+                lines.append((1, line.id, {'requested_date': requested_date}))
+            result['value'] = {'order_line': lines}
+        return result
 
 
 class SaleOrderLine(models.Model):

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    requested_date = fields.Date(string='Requested Date')

--- a/sale_order_line_dates/views/sale_order_view.xml
+++ b/sale_order_line_dates/views/sale_order_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="sale_order_requested_date_form_view">
+            <field name="name">sale.order.requested.date.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_sale_orderfor"/>
+            <field name="arch" type="xml">
+                <field name="order_line" position="attributes">
+                    <attribute name="context">{'default_requested_date':requested_date}</attribute>
+                </field>
+                <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
+                    <field name="requested_date" />
+                </xpath>
+            </field>
+        </record>
+    
+    </data>
+</openerp>


### PR DESCRIPTION
Este modulo pretende realizar lo mismo que sale_delivery_date (https://github.com/odoomrp/odoomrp-wip/tree/8.0/sale_delivery_date), pero usando el modulo del estándar de odoo sale_order_dates, comentado por @clonedagain en el issue #219 
