### PR TITLE
[IMP sale_delivery_date]

### DIFF
--- a/sale_delivery_date/views/sale_order_view.xml
+++ b/sale_delivery_date/views/sale_order_view.xml
@@ -17,6 +17,15 @@
                 </xpath>
             </field>
         </record>
-    
+        <record model="ir.ui.view" id="view_order_tree_inh_delivery_date">
+            <field name="name">view.order.tree.inh.delivery.date</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_tree"/>
+            <field name="arch" type="xml">
+                <field name="date_order" position="after">
+                    <field name="delivery_date" />
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Se ha modificado este módulo por Alm reclamación CLM0042 - Filtrar por Día y Semana los Pedidos de Venta. 
A este módulo se le ha añadido que muestre el campo "delivery_date" en el tree de pedidos de venta.
