### PR TITLE
[IMP product_variant_default_code]

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -71,6 +71,6 @@ class ProductAttributeValue(models.Model):
     @api.model
     def create(self, values):
         if 'attribute_code' not in values:
-            values['attribute_code'] = values.get('name')[0:1]
+            values['attribute_code'] = values.get('name','')[0:1]
         value = super(ProductAttributeValue, self).create(values)
         return value

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -67,3 +67,10 @@ class ProductAttributeValue(models.Model):
 
     attribute_code = fields.Char(
         string='Attribute Code', default=onchange_name)
+
+    @api.model
+    def create(self, values):
+        if 'attribute_code' not in values:
+            values['attribute_code'] = values.get('name')[0:1]
+        value = super(ProductAttributeValue, self).create(values)
+        return value

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -71,6 +71,6 @@ class ProductAttributeValue(models.Model):
     @api.model
     def create(self, values):
         if 'attribute_code' not in values:
-            values['attribute_code'] = values.get('name','')[0:1]
+            values['attribute_code'] = values.get('name', '')[0:1]
         value = super(ProductAttributeValue, self).create(values)
         return value


### PR DESCRIPTION
Se ha modificado este módulo para que coja valor el campo "attribute_code" del objeto "product.attribute.value", para cuando se da de alta un valor de atributo desde un producto, no desde el formulario de valores de atributos. A petición de Ana.
