### PR TITLE
[ADD] procurement_mrp_no_confirm

### DIFF
--- a/procurement_mrp_no_confirm/__init__.py
+++ b/procurement_mrp_no_confirm/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/procurement_mrp_no_confirm/__openerp__.py
+++ b/procurement_mrp_no_confirm/__openerp__.py
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Procurement MRP no Confirm",
+    "version": "1.0",
+    "depends": ["mrp"],
+    "author": "OdooMRP team",
+    "category": "MRP",
+    "description": """
+        This module avoids the automatic confirmation of manufacturing order
+        when procurement orders are executed.
+    """,
+    'data': ["data/mrp_production_workflow.xml"],
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/procurement_mrp_no_confirm/data/mrp_production_workflow.xml
+++ b/procurement_mrp_no_confirm/data/mrp_production_workflow.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="mrp.prod_trans_draft_picking" model="workflow.transition">
+            <field name="act_from" ref="mrp.prod_act_draft"/>
+            <field name="act_to" ref="mrp.prod_act_confirmed"/>
+            <field name="signal">button_confirm</field>
+            <field name="condition">not no_confirm</field>
+        </record>
+    </data>
+</openerp>

--- a/procurement_mrp_no_confirm/i18n/es.po
+++ b/procurement_mrp_no_confirm/i18n/es.po
@@ -1,0 +1,32 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_mrp_no_confirm
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-20 16:56+0000\n"
+"PO-Revision-Date: 2014-11-20 17:57+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: procurement_mrp_no_confirm
+#: model:ir.model,name:procurement_mrp_no_confirm.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Órden de fabricación"
+
+#. module: procurement_mrp_no_confirm
+#: field:mrp.production,no_confirm:0
+msgid "No Confirm"
+msgstr "No confirmar"
+
+#. module: procurement_mrp_no_confirm
+#: model:ir.model,name:procurement_mrp_no_confirm.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+

--- a/procurement_mrp_no_confirm/i18n/procurement_mrp_no_confirm.pot
+++ b/procurement_mrp_no_confirm/i18n/procurement_mrp_no_confirm.pot
@@ -1,0 +1,32 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_mrp_no_confirm
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-20 16:56+0000\n"
+"PO-Revision-Date: 2014-11-20 17:57+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: procurement_mrp_no_confirm
+#: model:ir.model,name:procurement_mrp_no_confirm.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: procurement_mrp_no_confirm
+#: field:mrp.production,no_confirm:0
+msgid "No Confirm"
+msgstr ""
+
+#. module: procurement_mrp_no_confirm
+#: model:ir.model,name:procurement_mrp_no_confirm.model_procurement_order
+msgid "Procurement"
+msgstr ""
+

--- a/procurement_mrp_no_confirm/models/__init__.py
+++ b/procurement_mrp_no_confirm/models/__init__.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import procurement_order
+from . import mrp_production

--- a/procurement_mrp_no_confirm/models/mrp_production.py
+++ b/procurement_mrp_no_confirm/models/mrp_production.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class MrpProduction(model.Model):
+
+    _inherit = 'mrp.production'
+
+    no_confirm = fields.Boolean('No Confirm')

--- a/procurement_mrp_no_confirm/models/mrp_production.py
+++ b/procurement_mrp_no_confirm/models/mrp_production.py
@@ -19,7 +19,7 @@
 from openerp import models, fields
 
 
-class MrpProduction(model.Model):
+class MrpProduction(models.Model):
 
     _inherit = 'mrp.production'
 

--- a/procurement_mrp_no_confirm/models/procurement_order.py
+++ b/procurement_mrp_no_confirm/models/procurement_order.py
@@ -1,0 +1,32 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def write(self, vals):
+        production_obj = self.env['mrp.production']
+        if vals.get('production_id'):
+            production = production_obj.browse(vals['production_id'])
+            production.no_confirm = True
+        return super(ProcurementOrder, self).write(vals)


### PR DESCRIPTION
Este módulo evita que una orden de fabricación sea confirmada cuando se crea al ejecutar un abastecimiento a producir.
