### PR TITLE
[NEW purchase_requisition_display_order_line]

### DIFF
--- a/purchase_requisition_display_order_line/__init__.py
+++ b/purchase_requisition_display_order_line/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/purchase_requisition_display_order_line/__openerp__.py
+++ b/purchase_requisition_display_order_line/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+{
+    "name": "Purchase Requisition Display Order Line",
+    "version": "1.0",
+    "depends": [
+        "purchase_requisition",
+    ],
+    "author": "OdooMRP team",
+    "contributors": [
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+    ],
+    "category": "Purchase Management",
+    "website": "http://www.odoomrp.com",
+    "summary": "",
+    "description": """
+    This module displays the generated purchase lines, and make a button to
+    navigate to an editable tree line purchase order to change the date,
+    quantity, and unit price.
+    """,
+    "data": [
+        "views/purchase_requisition_view.xml",
+    ],
+    "installable": True,
+}

--- a/purchase_requisition_display_order_line/i18n/es.po
+++ b/purchase_requisition_display_order_line/i18n/es.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_requisition_display_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 12:10+0000\n"
+"PO-Revision-Date: 2014-11-21 13:11+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.requisition:purchase_requisition_display_order_line.view_purchase_requisition_form_inh_displayorderline
+msgid "Purchase Lines"
+msgstr "Líneas de compra"
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.order.line:purchase_requisition_display_order_line.purchase_order_line_tree_displayorderline
+msgid "Purchase Order Lines"
+msgstr "Líneas pedido de compra"
+
+#. module: purchase_requisition_display_order_line
+#: model:ir.model,name:purchase_requisition_display_order_line.model_purchase_requisition
+msgid "Purchase Requisition"
+msgstr "Solicitud de compra"
+
+#. module: purchase_requisition_display_order_line
+#: model:ir.actions.act_window,name:purchase_requisition_display_order_line.action_open_purchase_line_from_displayorderline
+msgid "Purchase order Line"
+msgstr "Línea de pedido de compra"
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.order.line:purchase_requisition_display_order_line.purchase_order_line_tree_displayorderline
+msgid "Supplier"
+msgstr "Proveedor"
+

--- a/purchase_requisition_display_order_line/i18n/purchase_requisition_display_order_line.pot
+++ b/purchase_requisition_display_order_line/i18n/purchase_requisition_display_order_line.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_requisition_display_order_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-21 12:10+0000\n"
+"PO-Revision-Date: 2014-11-21 12:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.requisition:purchase_requisition_display_order_line.view_purchase_requisition_form_inh_displayorderline
+msgid "Purchase Lines"
+msgstr ""
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.order.line:purchase_requisition_display_order_line.purchase_order_line_tree_displayorderline
+msgid "Purchase Order Lines"
+msgstr ""
+
+#. module: purchase_requisition_display_order_line
+#: model:ir.model,name:purchase_requisition_display_order_line.model_purchase_requisition
+msgid "Purchase Requisition"
+msgstr ""
+
+#. module: purchase_requisition_display_order_line
+#: model:ir.actions.act_window,name:purchase_requisition_display_order_line.action_open_purchase_line_from_displayorderline
+msgid "Purchase order Line"
+msgstr ""
+
+#. module: purchase_requisition_display_order_line
+#: view:purchase.order.line:purchase_requisition_display_order_line.purchase_order_line_tree_displayorderline
+msgid "Supplier"
+msgstr ""
+

--- a/purchase_requisition_display_order_line/models/__init__.py
+++ b/purchase_requisition_display_order_line/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import purchase_requisition

--- a/purchase_requisition_display_order_line/models/purchase_requisition.py
+++ b/purchase_requisition_display_order_line/models/purchase_requisition.py
@@ -17,16 +17,13 @@
 ##############################################################################
 
 import logging
-
-from openerp import models, api, exceptions
-from openerp import _
+from openerp import models, api
 
 _logger = logging.getLogger(__name__)
 
 
 class PurchaseRequisition(models.Model):
     _inherit = 'purchase.requisition'
-
 
     @api.multi
     def open_purchase_lines(self):
@@ -35,5 +32,5 @@ class PurchaseRequisition(models.Model):
             'purchase_requisition_display_order_line.action_open_purchase_line'
             '_from_displayorderline')
         po_line_ids = [po_line.id for po_line in self.po_line_ids]
-        result['domain'] = "[('id', 'in', " + str(po_line_ids) + ")]"
+        result['domain'] = [('id', 'in', po_line_ids)]
         return result

--- a/purchase_requisition_display_order_line/models/purchase_requisition.py
+++ b/purchase_requisition_display_order_line/models/purchase_requisition.py
@@ -1,0 +1,39 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+import logging
+
+from openerp import models, api, exceptions
+from openerp import _
+
+_logger = logging.getLogger(__name__)
+
+
+class PurchaseRequisition(models.Model):
+    _inherit = 'purchase.requisition'
+
+
+    @api.multi
+    def open_purchase_lines(self):
+        template_obj = self.env['product.template']
+        result = template_obj._get_act_window_dict(
+            'purchase_requisition_display_order_line.action_open_purchase_line'
+            '_from_displayorderline')
+        po_line_ids = [po_line.id for po_line in self.po_line_ids]
+        result['domain'] = "[('id', 'in', " + str(po_line_ids) + ")]"
+        return result

--- a/purchase_requisition_display_order_line/views/purchase_requisition_view.xml
+++ b/purchase_requisition_display_order_line/views/purchase_requisition_view.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_purchase_requisition_form_inh_displayorderline">
+            <field name="name">view.purchase.requisition.form.inh.displayorderline</field>
+            <field name="model">purchase.requisition</field>
+            <field name="inherit_id"
+                ref="purchase_requisition.view_purchase_requisition_form" />
+            <field name="arch" type="xml">
+                 <button name="open_rfq" position="before">
+                    <button name="open_purchase_lines" type="object" string="Purchase Lines" attrs="{'invisible': [('state', 'in', ('draft'))]}"/>
+                 </button>
+                <field name="purchase_ids" position="after">
+                    <separator string="Purchase Lines" />
+                    <field name="po_line_ids" nolabel="1" />
+                </field>
+            </field>
+        </record>
+        <record model="ir.ui.view" id="purchase_order_line_form_inh_displayorderline">
+            <field name="name">purchase.order.line.form.inh.displayorderline</field>
+            <field name="model">purchase.order.line</field>
+            <field name="inherit_id"
+                ref="purchase_requisition.purchase_order_line_tree_tender" />
+            <field name="arch" type="xml">
+                <field name="partner_id" position="before">
+                    <field name="order_id" />
+                </field>
+                <field name="product_id" position="after">
+                    <field name="date_planned" />
+                </field>
+                <button name="action_draft" position="replace" />
+                <button name="action_confirm" position="replace" />
+            </field>
+        </record>
+        <record id="purchase_order_line_tree_displayorderline" model="ir.ui.view">
+            <field name="name">purchase.order.line.tree.displayorderline</field>
+            <field name="model">purchase.order.line</field>
+            <field name="arch" type="xml">
+                <tree string="Purchase Order Lines"  editable="bottom">
+                    <field name="order_id" readonly="1"/>
+                    <field name="name" readonly="1"/>
+                    <field name="partner_id" string="Supplier" readonly="1"/>
+                    <field name="product_id" readonly="1"/>
+                    <field name="price_unit"/>
+                    <field name="product_qty"/>
+                    <field name="product_uom" groups="product.group_uom" readonly="1"/>
+                    <field name="price_subtotal" readonly="1"/>
+                    <field name="date_planned"  widget="date" width="135"/>
+                    <field name="state" invisible="1"/>
+                    <field name="invoiced" invisible="1"/>
+                </tree>
+            </field>
+        </record>
+        <record model="ir.actions.act_window" id="action_open_purchase_line_from_displayorderline">
+            <field name="name">Purchase order Line</field>
+            <field name="res_model">purchase.order.line</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="purchase_order_line_tree_displayorderline"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
El módulo "purchase_requisition_order_generator" desaparece, y donde esta instalado este módulo hay que instalar los módulos "purchase_requisition_auot_rfq", y este nuevo módulo.
Pedro.. he tenido que poner otra vez el str ya que sino me daba este error:

  File "/home/alfredo/OdooMRPOficina/purchase_requisition_display_order_line/models/purchase_requisition.py", line 38, in open_purchase_lines
    result['domain'] = "[('id', 'in', " + po_line_ids + ")]"
TypeError: cannot concatenate 'str' and 'list' objects

También os pediría que por favor cerraseis el issue https://github.com/odoomrp/odoomrp-wip/pull/356#issuecomment-63960559
