### PR TITLE
[FIX] When installing variants, it doesn't assign corresponding wo to sc...

### DIFF
--- a/mrp_operations_extension/README.rst
+++ b/mrp_operations_extension/README.rst
@@ -1,0 +1,9 @@
+MRP operations extension module
+===============================
+
+This module adds:
+
+- New table to store operations to avoid typing them again.
+- Adds a relation from WorkcenterLines to BOM Lists.
+- Adds a relation from WorkcenterLines to Manufacturing Orders in Scheduled/Consumed/Finished Products.
+- Adds a relation between Routing Work Center Lines and Work Center extra Info.

--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -21,13 +21,13 @@
     "version": "1.0",
     "category": "Manufacturing",
     "data": [
-         "wizard/mrp_workorder_produce_view.xml",
-         "views/mrp_workcenter_view.xml",
-         "views/mrp_routing_operation_view.xml",
-         "views/mrp_production_view.xml",
-         "views/mrp_bom_view.xml",
-         "views/mrp_routing_workcenter_view.xml",
-         "security/ir.model.access.csv"
+        "wizard/mrp_workorder_produce_view.xml",
+        "views/mrp_workcenter_view.xml",
+        "views/mrp_routing_operation_view.xml",
+        "views/mrp_production_view.xml",
+        "views/mrp_bom_view.xml",
+        "views/mrp_routing_workcenter_view.xml",
+        "security/ir.model.access.csv"
     ],
     "author": "OdooMRP team",
     "website": "http://www.odoomrp.com",

--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -27,10 +27,12 @@ class MrpProduction(models.Model):
         res = super(MrpProduction,
                     self)._action_compute_lines(properties=properties)
         self._get_workorder_in_product_lines(self.workcenter_lines,
-                                             self.product_lines)
+                                             self.product_lines,
+                                             properties=properties)
         return res
 
-    def _get_workorder_in_product_lines(self, workcenter_lines, product_lines):
+    def _get_workorder_in_product_lines(self, workcenter_lines, product_lines,
+                                        properties=None):
         for p_line in product_lines:
             for bom_line in self.bom_id.bom_line_ids:
                 if bom_line.product_id.id == p_line.product_id.id:
@@ -41,7 +43,8 @@ class MrpProduction(models.Model):
                 elif bom_line.type == 'phantom':
                     bom_obj = self.env['mrp.bom']
                     bom_id = bom_obj._bom_find(
-                        product_id=bom_line.product_id.id)
+                        product_id=bom_line.product_id.id,
+                        properties=properties)
                     for bom_line2 in bom_obj.browse(bom_id).bom_line_ids:
                         if bom_line2.product_id.id == p_line.product_id.id:
                             for wc_line in workcenter_lines:

--- a/mrp_operations_extension/views/mrp_bom_view.xml
+++ b/mrp_operations_extension/views/mrp_bom_view.xml
@@ -2,13 +2,16 @@
 <openerp>
     <data>
 
-    <record id="mrp_bom_form_view_inh" model="ir.ui.view">
+        <record id="mrp_bom_form_view_inh" model="ir.ui.view">
             <field name="name">mrp.bom.form.inh</field>
             <field name="model">mrp.bom</field>
             <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
             <field name="arch" type="xml">
-                <xpath expr="//tree/field[@name='product_id']" position="after">
-                   <field name="operation" domain="[('routing_id', '=', parent.routing_id)]"/>
+                <xpath expr="//tree/field[@name='product_id']"
+                    position="after">
+                    <field name="operation"
+                        domain="[('routing_id', '=', parent.routing_id)]"
+                        groups="mrp.group_mrp_routings" />
                 </xpath>
             </field>
         </record>

--- a/mrp_operations_extension/views/mrp_production_view.xml
+++ b/mrp_operations_extension/views/mrp_production_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="mrp.mrp_production_product_tree_view" />
             <field name="arch" type="xml">
                 <field name="product_id" position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </field>
             </field>
         </record>
@@ -19,7 +19,7 @@
             <field name="inherit_id" ref="mrp.mrp_production_product_form_view" />
             <field name="arch" type="xml">
                 <field name="product_id" position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </field>
             </field>
         </record>
@@ -32,22 +32,22 @@
                 <xpath
                     expr="//page//group[@string='Products to Consume']//field[@name='product_id']"
                     position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </xpath>
                 <xpath
                     expr="//page//group[@string='Consumed Products']//field[@name='product_id']"
                     position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </xpath>
                 <xpath
                     expr="//page//group[@string='Products to Produce']//field[@name='product_id']"
                     position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </xpath>
                 <xpath
                     expr="//page//group[@string='Produced Products']//field[@name='product_id']"
                     position="after">
-                    <field name="work_order" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" />
                 </xpath>
                 <xpath
                     expr="//field[@name='workcenter_lines']/form//field[@name='name']"

--- a/mrp_operations_extension/views/mrp_production_view.xml
+++ b/mrp_operations_extension/views/mrp_production_view.xml
@@ -8,7 +8,8 @@
             <field name="inherit_id" ref="mrp.mrp_production_product_tree_view" />
             <field name="arch" type="xml">
                 <field name="product_id" position="after">
-                    <field name="work_order" groups="mrp.group_mrp_routings" />
+                    <field name="work_order" groups="mrp.group_mrp_routings"
+                        domain="[('production_id', '=', production_id)]" />
                 </field>
             </field>
         </record>
@@ -19,7 +20,9 @@
             <field name="inherit_id" ref="mrp.mrp_production_product_form_view" />
             <field name="arch" type="xml">
                 <field name="product_id" position="after">
-                    <field name="work_order" groups="mrp.group_mrp_routings" />
+                    <field name="production_id" invisible="1" />
+                    <field name="work_order" groups="mrp.group_mrp_routings" 
+                        domain="[('production_id', '=', production_id)]" />
                 </field>
             </field>
         </record>

--- a/mrp_product_variants/__openerp__.py
+++ b/mrp_product_variants/__openerp__.py
@@ -22,13 +22,14 @@
     "depends": [
         "product",
         "mrp",
-        "mrp_operations_extension",
         "product_variants_no_automatic_creation",
         "mrp_production_editable_scheduled_products",
     ],
     "author": "OdooMRP team",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <ajuaristio@gmail.com>",
     ],
     "category": "Custom Module",
     "website": "http://www.odoomrp.com",

--- a/mrp_product_variants/__openerp__.py
+++ b/mrp_product_variants/__openerp__.py
@@ -22,7 +22,6 @@
     "depends": [
         "product",
         "mrp",
-        "mrp_operations",
         "mrp_operations_extension",
         "product_variants_no_automatic_creation",
         "mrp_production_editable_scheduled_products",

--- a/mrp_product_variants/__openerp__.py
+++ b/mrp_product_variants/__openerp__.py
@@ -22,6 +22,7 @@
     "depends": [
         "product",
         "mrp",
+        "mrp_operations",
         "mrp_operations_extension",
         "product_variants_no_automatic_creation",
         "mrp_production_editable_scheduled_products",

--- a/mrp_product_variants/models/mrp_bom.py
+++ b/mrp_product_variants/models/mrp_bom.py
@@ -63,6 +63,17 @@ class MrpBom(models.Model):
     def _bom_explode(self, bom, product, factor, properties=None, level=0,
                      routing_id=False, previous_products=None,
                      master_bom=None, production=None):
+        result, result2 = self._bom_explode_variants(
+            bom, product, factor, properties=properties, level=level,
+            routing_id=routing_id, previous_products=previous_products,
+            master_bom=master_bom, production=production)
+        return result, result2
+
+    @api.model
+    def _bom_explode_variants(
+            self, bom, product, factor, properties=None, level=0,
+            routing_id=False, previous_products=None, master_bom=None,
+            production=None):
         """ Finds Products and Work Centers for related BoM for manufacturing
         order.
         @param bom: BoM of particular product template.
@@ -203,7 +214,8 @@ class MrpBom(models.Model):
                 res = self._bom_explode(
                     bom2, bom_line_id.product_id, quantity2,
                     properties=properties, level=level + 10,
-                    previous_products=all_prod, master_bom=master_bom)
+                    previous_products=all_prod, master_bom=master_bom,
+                    production=production)
                 result = result + res[0]
                 result2 = result2 + res[1]
             else:
@@ -215,7 +227,4 @@ class MrpBom(models.Model):
                     _('Invalid Action! BoM "%s" contains a phantom BoM line'
                       ' but the product "%s" does not have any BoM defined.') %
                     (master_bom.name, name))
-
-        self._get_workorder_operations(result2, level=level,
-                                       routing_id=routing_id)
         return result, result2

--- a/mrp_product_variants/models/mrp_bom.py
+++ b/mrp_product_variants/models/mrp_bom.py
@@ -79,6 +79,7 @@ class MrpBom(models.Model):
         @return: result: List of dictionaries containing product details.
                  result2: List of dictionaries containing Work Center details.
         """
+        routing_id = bom.routing_id.id or routing_id
         uom_obj = self.env["product.uom"]
         routing_obj = self.env['mrp.routing']
         master_bom = master_bom or bom

--- a/mrp_product_variants/models/mrp_production.py
+++ b/mrp_product_variants/models/mrp_production.py
@@ -105,6 +105,11 @@ class MrpProduction(models.Model):
 
     @api.multi
     def _action_compute_lines(self, properties=None):
+        results, results2 = self._action_compute_lines_variants(properties=properties)
+        return results, results2
+
+    @api.multi
+    def _action_compute_lines_variants(self, properties=None):
         """ Compute product_lines and workcenter_lines from BoM structure
         @return: product_lines
         """
@@ -161,52 +166,7 @@ class MrpProduction(models.Model):
             for line in results2:
                 line['production_id'] = production.id
                 workcenter_line_obj.create(line)
-
-            self._compute_planned_workcenter()
-            self._get_workorder_in_product_lines(self.workcenter_lines,
-                                                 self.product_lines,
-                                                 properties=properties)
-        return results
-
-    def _get_workorder_in_product_lines(self, workcenter_lines, product_lines,
-                                        properties=None):
-        for p_line in product_lines:
-            for bom_line in self.bom_id.bom_line_ids:
-                if ((bom_line.product_template.id == p_line.product_template.id
-                        or bom_line.product_id.product_tmpl_id.id ==
-                        p_line.product_template.id) and
-                        (not bom_line.product_id or
-                         bom_line.product_id.id == p_line.product_id.id)):
-                    for wc_line in workcenter_lines:
-                        if wc_line.routing_wc_line == bom_line.operation:
-                            p_line.work_order = wc_line
-                            break
-                elif bom_line.type == 'phantom':
-                    bom_obj = self.env['mrp.bom']
-                    if not bom_line.product_id:
-                        bom_id = bom_obj._bom_find(
-                            product_tmpl_id=bom_line.product_template.id,
-                            properties=properties)
-                    else:
-                        bom_id = bom_obj._bom_find(
-                            product_id=bom_line.product_id.id,
-                            properties=properties)
-                    for bom_line2 in bom_obj.browse(bom_id).bom_line_ids:
-                        if ((bom_line2.product_template.id ==
-                                p_line.product_template.id
-                                or bom_line2.product_id.product_tmpl_id.id ==
-                                p_line.product_template.id) and
-                                (not bom_line2.product_id or
-                                 bom_line2.product_id.id ==
-                                 p_line.product_id.id)):
-                            for wc_line in workcenter_lines:
-                                if (wc_line.routing_wc_line.id ==
-                                        bom_line2.operation.id):
-                                    p_line.work_order = wc_line.id
-                                    break
-
-    def action_confirm(self):
-        super(MrpProduction, self).action_confirm()
+        return results, results2
 
     @api.model
     def _make_production_produce_line(self, production):

--- a/mrp_product_variants/models/mrp_production.py
+++ b/mrp_product_variants/models/mrp_production.py
@@ -105,8 +105,8 @@ class MrpProduction(models.Model):
 
     @api.multi
     def _action_compute_lines(self, properties=None):
-        results, results2 = self._action_compute_lines_variants(properties=properties)
-        return results, results2
+        results = self._action_compute_lines_variants(properties=properties)
+        return results
 
     @api.multi
     def _action_compute_lines_variants(self, properties=None):
@@ -166,7 +166,7 @@ class MrpProduction(models.Model):
             for line in results2:
                 line['production_id'] = production.id
                 workcenter_line_obj.create(line)
-        return results, results2
+        return results
 
     @api.model
     def _make_production_produce_line(self, production):

--- a/mrp_product_variants/models/mrp_production.py
+++ b/mrp_product_variants/models/mrp_production.py
@@ -228,7 +228,8 @@ class MrpProduction(models.Model):
                     {'product_tmpl_id': production.product_template.id,
                      'attribute_value_ids': [(6, 0, att_values_ids)]})
             production.product_id = product
-        super(MrpProduction, self)._make_production_produce_line(production)
+        return super(MrpProduction,
+                     self)._make_production_produce_line(production)
 
     @api.model
     def _make_production_consume_line(self, line):
@@ -250,7 +251,7 @@ class MrpProduction(models.Model):
                     {'product_tmpl_id': line.product_template.id,
                      'attribute_value_ids': [(6, 0, att_values_ids)]})
             line.product_id = product
-        super(MrpProduction, self)._make_production_consume_line(line)
+        return super(MrpProduction, self)._make_production_consume_line(line)
 
 
 class MrpProductionProductLineAttribute(models.Model):

--- a/mrp_product_variants_operations/README.rst
+++ b/mrp_product_variants_operations/README.rst
@@ -1,0 +1,4 @@
+This is an auto install module.
+
+It is required for mrp_operations_extension and mrp_product_variants to work
+properly when both are installed.

--- a/mrp_product_variants_operations/__init__.py
+++ b/mrp_product_variants_operations/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/mrp_product_variants_operations/__openerp__.py
+++ b/mrp_product_variants_operations/__openerp__.py
@@ -11,46 +11,27 @@
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
 #
-#    You should have received a copy of the GNU General Public License
+#    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 ##############################################################################
 
 {
-    "name": "MRP Operations Extension",
+    "name": "MRP - Product variants with MRP operations",
     "version": "1.0",
-    "category": "Manufacturing",
-    "data": [
-         "wizard/mrp_workorder_produce_view.xml",
-         "views/mrp_workcenter_view.xml",
-         "views/mrp_routing_operation_view.xml",
-         "views/mrp_production_view.xml",
-         "views/mrp_bom_view.xml",
-         "views/mrp_routing_workcenter_view.xml",
-         "security/ir.model.access.csv"
-    ],
+    "depends": [
+        "mrp_product_variants",
+        "mrp_operations_extension"],
     "author": "OdooMRP team",
     "website": "http://www.odoomrp.com",
     "contributors": [
-        "Daniel Campos <danielcampos@avanzosc.es>",
-        "Mikel Arregi <mikelarregi@avanzosc.es>",
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
         "Ana Juaristi <ajuaristio@gmail.com>",
     ],
-    "depends": [
-        "mrp_operations",
-        "mrp",
-        "stock",
-    ],
-    "data": [
-        "wizard/mrp_workorder_produce_view.xml",
-        "views/mrp_workcenter_view.xml",
-        "views/mrp_routing_operation_view.xml",
-        "views/mrp_production_view.xml",
-        "views/mrp_bom_view.xml",
-        "views/mrp_routing_workcenter_view.xml",
-        "security/ir.model.access.csv",
-    ],
-    "installable": True
+    "category": "Custom Module",
+    "summary": "",
+    "data": [],
+    "installable": True,
+    "auto_install": True,
 }

--- a/mrp_product_variants_operations/models/__init__.py
+++ b/mrp_product_variants_operations/models/__init__.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import mrp_bom
+from . import mrp_production

--- a/mrp_product_variants_operations/models/mrp_bom.py
+++ b/mrp_product_variants_operations/models/mrp_bom.py
@@ -1,0 +1,37 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class MrpBom(models.Model):
+    _inherit = 'mrp.bom'
+
+    @api.model
+    def _bom_explode_variants(
+            self, bom, product, factor, properties=None, level=0,
+            routing_id=False, previous_products=None, master_bom=None,
+            production=None):
+        routing_id = bom.routing_id.id or routing_id
+        result, result2 = super(MrpBom, self)._bom_explode_variants(
+            bom, product, factor, properties=properties, level=level,
+            routing_id=routing_id, previous_products=previous_products,
+            master_bom=master_bom, production=production)
+        self._get_workorder_operations(result2, level=level,
+                                       routing_id=routing_id)
+        return result, result2

--- a/mrp_product_variants_operations/models/mrp_bom.py
+++ b/mrp_product_variants_operations/models/mrp_bom.py
@@ -23,6 +23,16 @@ class MrpBom(models.Model):
     _inherit = 'mrp.bom'
 
     @api.model
+    def _bom_explode(
+            self, bom, product, factor, properties=None, level=0,
+            routing_id=False, previous_products=None, master_bom=None,
+            production=None):
+        return self._bom_explode_variants(
+            bom, product, factor, properties=properties, level=level,
+            routing_id=routing_id, previous_products=previous_products,
+            master_bom=master_bom, production=production)
+
+    @api.model
     def _bom_explode_variants(
             self, bom, product, factor, properties=None, level=0,
             routing_id=False, previous_products=None, master_bom=None,

--- a/mrp_product_variants_operations/models/mrp_production.py
+++ b/mrp_product_variants_operations/models/mrp_production.py
@@ -1,0 +1,71 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.multi
+    def _action_compute_lines_variants(self, properties=None):
+        results = super(MrpProduction, self)._action_compute_lines_variants(
+            properties=properties)
+        self._compute_planned_workcenter()
+        self._get_workorder_in_product_lines(self.workcenter_lines,
+                                             self.product_lines,
+                                             properties=properties)
+        return results
+
+    def _get_workorder_in_product_lines(self, workcenter_lines, product_lines,
+                                        properties=None):
+        for p_line in product_lines:
+            for bom_line in self.bom_id.bom_line_ids:
+                if ((bom_line.product_template.id == p_line.product_template.id
+                        or bom_line.product_id.product_tmpl_id.id ==
+                        p_line.product_template.id) and
+                        (not bom_line.product_id or
+                         bom_line.product_id.id == p_line.product_id.id)):
+                    for wc_line in workcenter_lines:
+                        if wc_line.routing_wc_line == bom_line.operation:
+                            p_line.work_order = wc_line
+                            break
+                    continue
+                elif bom_line.type == 'phantom':
+                    bom_obj = self.env['mrp.bom']
+                    if not bom_line.product_id:
+                        bom_id = bom_obj._bom_find(
+                            product_tmpl_id=bom_line.product_template.id,
+                            properties=properties)
+                    else:
+                        bom_id = bom_obj._bom_find(
+                            product_id=bom_line.product_id.id,
+                            properties=properties)
+                    for bom_line2 in bom_obj.browse(bom_id).bom_line_ids:
+                        if ((bom_line2.product_template.id ==
+                                p_line.product_template.id
+                                or bom_line2.product_id.product_tmpl_id.id ==
+                                p_line.product_template.id) and
+                                (not bom_line2.product_id or
+                                 bom_line2.product_id.id ==
+                                 p_line.product_id.id)):
+                            for wc_line in workcenter_lines:
+                                if (wc_line.routing_wc_line.id ==
+                                        bom_line2.operation.id):
+                                    p_line.work_order = wc_line
+                                    break


### PR DESCRIPTION
...heduled product

Resulta que algo que hace el extension no se habia replicado en el variants, de hay que el error de #394 se siguiera repitiendo aún habiendo corregido el modulo `mrp_operations_extensions`
