### PR TITLE
[IMP] Limit to not add products from work order tree

### DIFF
--- a/mrp_operations_extension/views/mrp_production_view.xml
+++ b/mrp_operations_extension/views/mrp_production_view.xml
@@ -91,7 +91,7 @@
                                 <field name="routing_wc_line"
                                     colspan="4" />
                                 <field name="product_line"
-                                    nolabel="1" colspan="4" />
+                                    nolabel="1" colspan="4"/>
                             </group>
                         </page>
                         <page string="Information">
@@ -199,7 +199,7 @@
                         <field name="routing_wc_line" colspan="4"
                             col="4" />
                         <field name="product_line" nolabel="1"
-                            colspan="4" col="4" />
+                            colspan="4" col="4" readonly="1"/>
                     </group>
                 </page>
                 <group string="Product to Produce" position="replace" />


### PR DESCRIPTION
Limitada la posibilidad de añadir productos desde el tree del Work Order ya que no genera movimiento ni linka el producto añadido con la orden de producción.
Hay que utilizar el módulo mrp_production_add_middle_stuff_operations.
