### PR TITLE
[FIX] Warning in a constraint

### DIFF
--- a/quality_control_samples/models/qc_sample.py
+++ b/quality_control_samples/models/qc_sample.py
@@ -42,7 +42,7 @@ class QcSample(models.Model):
                 _('Min value cannot be bigger than max value.'))
 
     @api.one
-    @api.constrains('from', 'to', 'sample')
+    @api.constrains('min_qty', 'max_qty', 'sample')
     def _check_ranges(self):
         domain = [('id', '!=', self.id),
                   ('sample', '=', self.sample.id),


### PR DESCRIPTION
En el log se puede ver el siguiente warning:

```
WARNING openerp_template openerp.models: @constrains('from', 'to', 'sample') parameters must be field names
```

Existen dos constraints, lo que no estoy segura es de si se pueden englobar en uno sin problemas, que dices @pedrobaeza 
