### PR TITLE
[IMP] mrp_lot_reserve: Refactoriced to hooked function use

### DIFF
--- a/mrp_production_add_middle_stuff_lot/wizard/wizard_addition.py
+++ b/mrp_production_add_middle_stuff_lot/wizard/wizard_addition.py
@@ -27,9 +27,7 @@ class WizProductionProductLine(models.TransientModel):
 
     @api.multi
     def add_product(self):
-        st_move_obj = self.env['stock.move']
         production_obj = self.env['mrp.production']
-        mppl_obj = self.env['mrp.production.product.line']
         if self.lot:
             available = production_obj._check_lot_quantity(
                 self.lot.id, self.production_id.location_src_id.id,
@@ -39,19 +37,4 @@ class WizProductionProductLine(models.TransientModel):
                     _('No Lot Available'), _('There is no lot %s available for'
                                              ' product') % (self.lot.name))
         res = super(WizProductionProductLine, self).add_product()
-        if self.lot:
-            # LF stock.move
-            move = st_move_obj.search(
-                [('raw_material_production_id', '=', self.production_id.id),
-                 ('product_id', '=', self.product_id.id),
-                 ('product_qty', '=', self.product_qty),
-                 ('state', '=', 'draft')], order='id DESC')
-            # LF mrp.production.product.line
-            mppl = mppl_obj.search(
-                [('production_id', '=', self.production_id.id),
-                 ('product_id', '=', self.product_id.id),
-                 ('product_qty', '=', self.product_qty)], order='id DESC')
-            if move and mppl:
-                move[0].restrict_lot_id = self.lot.id
-                mppl[0].lot = self.lot.id
         return res


### PR DESCRIPTION
He modificado el módulo ya que he visto que existe una función creo que diseñada para usarla de hook .

```
    def _make_production_consume_line(self, cr, uid, line, context=None):
        return self._make_consume_line_from_data(cr, uid, line.production_id, line.product_id, line.product_uom.id, line.product_qty, line.product_uos.id, line.product_uos_qty, context=context)
```

Y simplifica la función que yo utilizo.
