### PR TITLE
Use a reference mask to control the output of variant default code

### DIFF
--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -1,16 +1,22 @@
 Product Variant Default Code(product_variant_default_code)
 -----------------------------------------------------------
 
-#. In 'product.template' object 'variant_reference mask' field is added
+#. In 'product.template' object new field 'Variant reference mask' is added
 
-#. In 'product.attribute.value' object is added the new field
-        'Attribute Code'.
+#. In 'product.attribute.value' object new field 'Attribute Code' is added.
 
-#. Reference mask is automatically created according to the attribute 
-        line settings on the product template. The mask can be changed
-        adaptively later on and the default code for vaiants will be
-        generated accodingly.
+#. When creating a new product template without specifying the 'Variant reference mask', a default value for 'Variant reference mask' will be automatically generated according to the attribute line settings on the product template. The mask will then be used as an instruction to generate default code of each product variant of the product template with the corresponding Attribute Code (of the attribute value) inserted. Besides the default value, 'Variant refernce mask' can be configure to your liking, make sure puting Attribut Name inside '[]' mark. 
 
-#. Reference code field of product is calculated automatically, taking as
-        the value of the new field 'Attribute Code'.
+#. Example:
+
+Creating a product named 'A' with two attributes, 'Size' and 'Color'::
+
+   Product: A
+   Color: Red(r), Yellow(y), Black(b) #Red, Yellow, Black are the attribute value, 'r', 'y', 'b' are the corresponding code
+   Size: L (l), XL(x)
+   
+The automatically generated default value for the Variant reference mask will be `[Color]-[Size]` and then the 'default code' on the variants will be something like `r-l` `b-l` `r-x` ...
+
+If you like, you can change the mask value whatever you like. You can even have the attribute name appear more than once in the mask such as , `fancyA/[Size]~[Color]~[Size]`, when saved the default code on variants will be something like `fancyA/l~r~l` (for variant with Color "Red" and Size "L") `fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL")
+
 

--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -1,0 +1,16 @@
+Product Variant Default Code(product_variant_default_code)
+-----------------------------------------------------------
+
+#. In 'product.template' object 'variant_reference mask' field is added
+
+#. In 'product.attribute.value' object is added the new field
+        'Attribute Code'.
+
+#. Reference mask is automatically created according to the attribute 
+        line settings on the product template. The mask can be changed
+        adaptively later on and the default code for vaiants will be
+        generated accodingly.
+
+#. Reference code field of product is calculated automatically, taking as
+        the value of the new field 'Attribute Code'.
+

--- a/product_variant_default_code/__openerp__.py
+++ b/product_variant_default_code/__openerp__.py
@@ -18,7 +18,7 @@
 {
     "name": "Product Variant Default Code",
     "version": "2.0",
-    "author": "Shine IT(http:www.openerp.cn), OdooMRP team",
+    "author": "Shine IT(http://www.openerp.cn), OdooMRP team",
     "contributors": "Tony Gu<tony@openerp.cn>",
     "category": "Product",
     "website": "http://www.odoomrp.com",

--- a/product_variant_default_code/__openerp__.py
+++ b/product_variant_default_code/__openerp__.py
@@ -30,7 +30,7 @@
     2.- In 'product.attribute.value' object is added the new field
         'Attribute Code'.
 
-    3.- Reference mask is automatically created according to the attribute 
+    3.- Reference mask is automatically created according to the attribute
         line settings on the product template. The mask can be changed
         adaptively later on and the default code for vaiants will be
         generated accodingly.

--- a/product_variant_default_code/__openerp__.py
+++ b/product_variant_default_code/__openerp__.py
@@ -17,17 +17,25 @@
 ##############################################################################
 {
     "name": "Product Variant Default Code",
-    "version": "1.0",
-    "author": "OdooMRP team",
+    "version": "2.0",
+    "author": "Shine IT(http:www.openerp.cn), OdooMRP team",
+    "contributors": "Tony Gu<tony@openerp.cn>",
     "category": "Product",
     "website": "http://www.odoomrp.com",
     "description": """
     This module adds:
 
-    1.- In 'product.attribute.value' object is added the new field
+    1.- In 'product.template' object 'variant_reference mask' field is added
+
+    2.- In 'product.attribute.value' object is added the new field
         'Attribute Code'.
 
-    2.- Reference code field of product is calculated automatically, taking as
+    3.- Reference mask is automatically created according to the attribute 
+        line settings on the product template. The mask can be changed
+        adaptively later on and the default code for vaiants will be
+        generated accodingly.
+
+    4.- Reference code field of product is calculated automatically, taking as
         the value of the new field 'Attribute Code'.
     """,
     "depends": ['product',

--- a/product_variant_default_code/__openerp__.py
+++ b/product_variant_default_code/__openerp__.py
@@ -19,25 +19,11 @@
     "name": "Product Variant Default Code",
     "version": "2.0",
     "author": "Shine IT(http://www.openerp.cn), OdooMRP team",
-    "contributors": "Tony Gu<tony@openerp.cn>",
+    "contributors": [
+        "Tony Gu<tony@openerp.cn>",
+        ],
     "category": "Product",
     "website": "http://www.odoomrp.com",
-    "description": """
-    This module adds:
-
-    1.- In 'product.template' object 'variant_reference mask' field is added
-
-    2.- In 'product.attribute.value' object is added the new field
-        'Attribute Code'.
-
-    3.- Reference mask is automatically created according to the attribute
-        line settings on the product template. The mask can be changed
-        adaptively later on and the default code for vaiants will be
-        generated accodingly.
-
-    4.- Reference code field of product is calculated automatically, taking as
-        the value of the new field 'Attribute Code'.
-    """,
     "depends": ['product',
                 ],
     "data": ['views/product_attribute_value_view.xml',

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -109,7 +109,8 @@ class ProductProduct(models.Model):
     @api.model
     def create(self, values):
         product = super(ProductProduct, self).create(values)
-        render_default_code(product, product.reference_mask)
+        if product.reference_mask:
+            render_default_code(product, product.reference_mask)
         return product
 
 

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -110,8 +110,7 @@ class ProductProduct(models.Model):
     @api.model
     def create(self, values):
         product = super(ProductProduct, self).create(values)
-        if product.attribute_value_ids:
-            render_default_code(product, product.reference_mask)
+        render_default_code(product, product.reference_mask)
         return product
 
 

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -87,12 +87,13 @@ class ProductTemplate(models.Model):
                 attribute_names.append("[{}]".format(line.attribute_id.name))
             default_mask = DEFAULT_REFERENCE_SEPERATOR.join(attribute_names)
             vals['reference_mask'] = default_mask
-        elif product.attribute_line_ids:
+        elif vals.get('reference_mask'):
             sanitize_reference_mask(product, vals['reference_mask'])
         return super(ProductTemplate, self).create(vals)
 
     @api.one
     def write(self, vals):
+        result = super(ProductTemplate, self).write(vals)
         if vals.get('reference_mask'):
             sanitize_reference_mask(self, vals['reference_mask'])
             product_obj = self.env['product.product']
@@ -100,7 +101,7 @@ class ProductTemplate(models.Model):
             products = product_obj.search(cond)
             for product in products:
                 render_default_code(product, vals['reference_mask'])
-        return super(ProductTemplate, self).write(vals)
+        return result
 
 
 class ProductProduct(models.Model):

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -59,7 +59,7 @@ def render_default_code(product, mask):
     missing_attrs = all_attrs - set(product_attrs.keys())
     missing = dict.fromkeys(missing_attrs, PLACE_HOLDER_4_MISSING_VALUE)
     product_attrs.update(missing)
-    default_code = reference_mask.substitute(product_attrs)
+    default_code = reference_mask.safe_substitute(product_attrs)
     product.default_code = default_code
 
 

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -68,12 +68,27 @@ class ProductTemplate(models.Model):
 
     reference_mask = fields.Char(
         string='Variant reference mask',
-        help='Reference mask for building internal references of a'
-             'variant generated from this template.'
-             'eg. "PREFIX-[r]-[d]-[f]-APPENDIX" where the "[]" surrounded '
-             'string like "r,d,f" are attribute name for the current product '
-             'When rendering, the "[xxx]" part will be replaced '
-             'by the corresponding code of attribute value for the variant.\n'
+        help='Reference mask for building internal references of a '
+             'variant generated from this template.\n'
+
+             'Example:\n'
+             'A product named ABC with 2 attributes: Size and Color:\n'
+
+             'Product: ABC\n'
+             'Color: Red(r), Yellow(y), Black(b)  #Red, Yellow, Black are '
+             'the attribute value, `r`, `y`, `b` are the corresponding code\n'
+             'Size: L (l), XL(x)\n'
+
+             'When setting Variant reference mask to `[Color]-[Size]`, the '
+             'default code on the variants will be something like `r-l` '
+             '`b-l` `r-x` ...\n'
+
+             'If you like, You can even have the attribute name appear more'
+             ' than once in the mask. Such as , `fancyA/[Size]~[Color]~[Size]`'
+             ' When saved, the default code on variants will be something like'
+             ' `fancyA/l~r~l` (for variant with Color "Red" and Size "L") '
+             '`fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL")\n'
+
              'Note: make sure characters "[,]" do not appear in your '
              'attribute name')
 

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -15,9 +15,8 @@
 #    along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 ##############################################################################
-from openerp import models, fields, api
+from openerp import models, fields, api, _
 from openerp.exceptions import except_orm
-from openerp.tools.translate import _
 import re
 from string import Template
 from collections import defaultdict

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -7,8 +7,8 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
                 <field name="default_code" position="before">
-                    <field name="default_prefix"
-                           attrs="{'invisible': [('product_variant_count', '=', 1)]}"/>
+                  <field name="reference_mask"
+                           modifiers="{'invisible': [['attribute_line_ids', '=', False]]}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Instead of hard coding the default code sequence for variant, with this enhancement user can set up a reference mask to make the default code of product variant adapted to his need.

A default reference mask will also be generated automatically.
