### PR TITLE
[IMP mrp_bom_version]

### DIFF
--- a/mrp_bom_version/models/mrp.py
+++ b/mrp_bom_version/models/mrp.py
@@ -28,6 +28,10 @@ class MrpBom(models.Model):
         },
     }
 
+    active = fields.Boolean(
+        readonly=True, default=False, copy=False,
+        help="If the active field is set to False, it will allow you to hide"
+             " the bills of material without removing it.")
     historical_date = fields.Date(string='Historical Date', readonly=True)
     state = fields.Selection([('draft', 'Draft'),
                               ('active', 'Active'),
@@ -61,11 +65,13 @@ class MrpBom(models.Model):
 
     @api.multi
     def button_active(self):
-        return self.write({'state': 'active'})
+        return self.write({'active': True,
+                           'state': 'active'})
 
     @api.multi
     def button_historical(self):
-        return self.write({'state': 'historical',
+        return self.write({'active': False,
+                           'state': 'historical',
                            'historical_date': fields.Date.today()})
 
 

--- a/mrp_bom_version/views/mrp_bom_view.xml
+++ b/mrp_bom_version/views/mrp_bom_view.xml
@@ -92,6 +92,9 @@
                 <field name="message_ids" position="attributes">
                     <attribute name="attrs">{'readonly':[('state', '=', 'historical')]}</attribute>
                 </field>
+                <field name="active" position="attributes">
+                    <attribute name="readonly">1</attribute>
+                </field>
             </field>
         </record>
         <record id="view_mrp_bom_filter_inh_version" model="ir.ui.view">


### PR DESCRIPTION
Se ha modificado este módulo para que cuando se cree la lista de materiales lo haga con el campo "active" igual a "False". Cuando se pincha el botón "activo", el campo "active" lo pondremo a True, y cuando se pinche el botón "Histórico", se pondrá el campo "active" a False. 
También se ha puesto el campo "active" como no editable.
