### PR TITLE
[IMP] no cargar empresa a no ser que se especifique en el asistente

### DIFF
--- a/procurement_purchase_forecast/wizard/purchase_forecast_load.py
+++ b/procurement_purchase_forecast/wizard/purchase_forecast_load.py
@@ -102,7 +102,7 @@ class PurchaseForecastLoad(models.TransientModel):
         res = {}
         for purchase in purchases:
             forecast = self.forecast_id.id
-            partner = purchase.order_id.partner_id.id
+            partner = self.partner_id.id
             product = purchase.product_id.id
             forecast_lines = forecast_line_obj.search(
                 [('product_id', '=', product),

--- a/procurement_sale_forecast/wizard/sale_forecast_load.py
+++ b/procurement_sale_forecast/wizard/sale_forecast_load.py
@@ -103,7 +103,7 @@ class SaleForecastLoad(models.TransientModel):
         for sale in sales:
             forecast = self.forecast_id.id
             product = sale.product_id.id
-            partner = sale.order_id.partner_id.id
+            partner = self.partner_id.id or False
             forecast_lines = forecast_line_obj.search(
                 [('product_id', '=', product),
                  ('partner_id', '=', partner),

--- a/procurement_sale_forecast/wizard/sale_forecast_load.py
+++ b/procurement_sale_forecast/wizard/sale_forecast_load.py
@@ -103,7 +103,7 @@ class SaleForecastLoad(models.TransientModel):
         for sale in sales:
             forecast = self.forecast_id.id
             product = sale.product_id.id
-            partner = self.partner_id.id or False
+            partner = self.partner_id.id
             forecast_lines = forecast_line_obj.search(
                 [('product_id', '=', product),
                  ('partner_id', '=', partner),


### PR DESCRIPTION
En base al issue #577 
En el asistente de carga de líneas de previsión, no cargar el cliente a menos que se especifique.
