### PR TITLE
[ADD] procurement_orderpoint_no_confirm

### DIFF
--- a/procurement_orderpoint_no_confirm/README.rst
+++ b/procurement_orderpoint_no_confirm/README.rst
@@ -1,0 +1,6 @@
+Procurement Orderpoint No Confirm
+=================================
+This module avoids the automatic confirmation of procurement order when
+procurement orders are created from orderpoint wizard.
+
+**Warning**: This module is incompatible with *procurement_jit*

--- a/procurement_orderpoint_no_confirm/__init__.py
+++ b/procurement_orderpoint_no_confirm/__init__.py
@@ -1,0 +1,20 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import wizard
+from . import models

--- a/procurement_orderpoint_no_confirm/__openerp__.py
+++ b/procurement_orderpoint_no_confirm/__openerp__.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Procurement Orderpoint No Confirm",
+    "version": "1.0",
+    "depends": ["stock"],
+    "author": "OdooMRP team",
+    "category": "MRP",
+    'data': [],
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/procurement_orderpoint_no_confirm/__openerp__.py
+++ b/procurement_orderpoint_no_confirm/__openerp__.py
@@ -21,9 +21,12 @@
     "version": "1.0",
     "depends": ["stock"],
     "author": "OdooMRP team",
-    "category": "MRP",
-    'data': [],
-    'demo': [],
+    "contributors": [
+        "Ainara Galdona <ainaragaldona@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "category": "Procurement",
     'installable': True,
     'auto_install': False,
 }

--- a/procurement_orderpoint_no_confirm/models/__init__.py
+++ b/procurement_orderpoint_no_confirm/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import procurement_order

--- a/procurement_orderpoint_no_confirm/models/procurement_order.py
+++ b/procurement_orderpoint_no_confirm/models/procurement_order.py
@@ -1,0 +1,34 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def run(self, autocommit=False):
+        config_param_obj = self.env['ir.config_parameter']
+        config_param_list = config_param_obj.search(
+            [('key', '=', 'procurement.order'), ('value', '=', 'no_confirm')])
+        if config_param_list:
+            config_param_list.unlink()
+        else:
+            super(ProcurementOrder, self).run(autocommit=autocommit)

--- a/procurement_orderpoint_no_confirm/wizard/__init__.py
+++ b/procurement_orderpoint_no_confirm/wizard/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import orderpoint_procurement

--- a/procurement_orderpoint_no_confirm/wizard/orderpoint_procurement.py
+++ b/procurement_orderpoint_no_confirm/wizard/orderpoint_procurement.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
-#
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
 #    published by the Free Software Foundation, either version 3 of the
@@ -28,7 +25,6 @@ class ProcurementCompute(models.TransientModel):
     @api.multi
     def procure_calculation(self):
         config_param_obj = self.env['ir.config_parameter']
-        for record in self:
-            config_param_obj.create({'key': 'procurement.order',
-                                     'value': 'no_confirm'})
+        config_param_obj.create({'key': 'procurement.order',
+                                 'value': 'no_confirm'})
         return super(ProcurementCompute, self).procure_calculation()

--- a/procurement_orderpoint_no_confirm/wizard/orderpoint_procurement.py
+++ b/procurement_orderpoint_no_confirm/wizard/orderpoint_procurement.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class ProcurementCompute(models.TransientModel):
+    _inherit = 'procurement.orderpoint.compute'
+
+    @api.multi
+    def procure_calculation(self):
+        config_param_obj = self.env['ir.config_parameter']
+        for record in self:
+            config_param_obj.create({'key': 'procurement.order',
+                                     'value': 'no_confirm'})
+        return super(ProcurementCompute, self).procure_calculation()


### PR DESCRIPTION
Este módulo no ejecuta los abastecimientos bajo stock que se crean al lanzar el asistente de stock minimo y maximo.
