### PR TITLE
[FIX product variant default code]

### DIFF
--- a/product_variant_default_code/README.rst
+++ b/product_variant_default_code/README.rst
@@ -1,22 +1,37 @@
 Product Variant Default Code(product_variant_default_code)
 -----------------------------------------------------------
 
-#. In 'product.template' object new field 'Variant reference mask' is added
+In 'product.template' object new field 'Variant reference mask' is added
 
-#. In 'product.attribute.value' object new field 'Attribute Code' is added.
+In 'product.attribute.value' object new field 'Attribute Code' is added.
 
-#. When creating a new product template without specifying the 'Variant reference mask', a default value for 'Variant reference mask' will be automatically generated according to the attribute line settings on the product template. The mask will then be used as an instruction to generate default code of each product variant of the product template with the corresponding Attribute Code (of the attribute value) inserted. Besides the default value, 'Variant refernce mask' can be configure to your liking, make sure puting Attribut Name inside '[]' mark. 
+When creating a new product template without specifying the 'Variant reference
+mask', a default value for 'Variant reference mask' will be automatically
+generated according to the attribute line settings on the product template.
+The mask will then be used as an instruction to generate default code of each
+product variant of the product template with the corresponding Attribute Code
+(of the attribute value) inserted. Besides the default value, 'Variant
+reference mask' can be configure to your liking, make sure puting Attribut Name
+inside '[]' mark. 
 
-#. Example:
+Example:
 
 Creating a product named 'A' with two attributes, 'Size' and 'Color'::
 
    Product: A
-   Color: Red(r), Yellow(y), Black(b) #Red, Yellow, Black are the attribute value, 'r', 'y', 'b' are the corresponding code
+   Color: Red(r), Yellow(y), Black(b) #Red, Yellow, Black are the attribute
+          value, 'r', 'y', 'b' are the corresponding code
    Size: L (l), XL(x)
    
-The automatically generated default value for the Variant reference mask will be `[Color]-[Size]` and then the 'default code' on the variants will be something like `r-l` `b-l` `r-x` ...
+The automatically generated default value for the Variant reference mask will
+be `[Color]-[Size]` and then the 'default code' on the variants will be
+something like `r-l` `b-l` `r-x` ...
 
-If you like, you can change the mask value whatever you like. You can even have the attribute name appear more than once in the mask such as , `fancyA/[Size]~[Color]~[Size]`, when saved the default code on variants will be something like `fancyA/l~r~l` (for variant with Color "Red" and Size "L") `fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL")
+If you like, you can change the mask value whatever you like. You can even have
+the attribute name appear more than once in the mask such as ,
+`fancyA/[Size]~[Color]~[Size]`, when saved the default code on variants will be
+something like `fancyA/l~r~l` (for variant with Color "Red" and Size "L")
+`fancyA/x~y~x` (for variant with Color "Yellow" and Size "XL").
 
-
+when the code attribute is changed, it automatically regenerates the 'default
+code'.

--- a/product_variant_default_code/i18n/es.po
+++ b/product_variant_default_code/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-16 10:45+0000\n"
-"PO-Revision-Date: 2015-01-16 12:01+0100\n"
+"POT-Creation-Date: 2015-01-21 11:56+0000\n"
+"PO-Revision-Date: 2015-01-21 12:58+0100\n"
 "Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,7 +21,7 @@ msgid "Attribute Code"
 msgstr "Código atributo"
 
 #. module: product_variant_default_code
-#: code:addons/product_variant_default_code/models/product.py:147
+#: code:addons/product_variant_default_code/models/product.py:152
 #: sql_constraint:product.attribute:0
 #, python-format
 msgid "Attribute Name must be unique!"
@@ -38,6 +38,11 @@ msgstr "Error"
 #, python-format
 msgid "Found unrecognized attribute name in \"Variant Reference Mask\""
 msgstr "Encontrado un nombre de atribuco no reconocido en la \"Referencia máscara variante\""
+
+#. module: product_variant_default_code
+#: field:product.product,manual_code:0
+msgid "Manual code"
+msgstr "Código manual"
 
 #. module: product_variant_default_code
 #: model:ir.model,name:product_variant_default_code.model_product_product

--- a/product_variant_default_code/i18n/es.po
+++ b/product_variant_default_code/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-12 16:00+0000\n"
-"PO-Revision-Date: 2014-11-12 17:02+0100\n"
+"POT-Creation-Date: 2015-01-16 10:45+0000\n"
+"PO-Revision-Date: 2015-01-16 12:01+0100\n"
 "Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,64 @@ msgid "Attribute Code"
 msgstr "Código atributo"
 
 #. module: product_variant_default_code
-#: field:product.template,default_prefix:0
-msgid "Reference prefix"
-msgstr "Prefijo de la referencia"
+#: code:addons/product_variant_default_code/models/product.py:147
+#: sql_constraint:product.attribute:0
+#, python-format
+msgid "Attribute Name must be unique!"
+msgstr "El nombre del atributo debe ser único!."
 
 #. module: product_variant_default_code
-#: help:product.template,default_prefix:0
-msgid "Prefix for using when building internal references for the variants generated from this template"
-msgstr "Prefijo para usar cuando se construyen las referencias internas para las variantes generadas desde esta plantilla"
+#: code:addons/product_variant_default_code/models/product.py:48
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: product_variant_default_code
+#: code:addons/product_variant_default_code/models/product.py:48
+#, python-format
+msgid "Found unrecognized attribute name in \"Variant Reference Mask\""
+msgstr "Encontrado un nombre de atribuco no reconocido en la \"Referencia máscara variante\""
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_attribute
+msgid "Product Attribute"
+msgstr "Atributo de producto"
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_variant_default_code
+#: help:product.template,reference_mask:0
+msgid ""
+"Reference mask for building internal references of a variant generated from this template.\n"
+"Example:\n"
+"A product named ABC with 2 attributes: Size and Color:\n"
+"Product: ABC\n"
+"Color: Red(r), Yellow(y), Black(b)  #Red, Yellow, Black are the attribute value, `r`, `y`, `b` are the corresponding code\n"
+"Size: L (l), XL(x)\n"
+"When setting Variant reference mask to `[Color]-[Size]`, the default code on the variants will be something like `r-l` `b-l` `r-x` ...\n"
+"If you like, You can even have the attribute name appear more than once in the mask. Such as , `fancyA/[Size]~[Color]~[Size]` When saved, the default code on variants will be something like `fancyA/l~r~l` (for variant with Color \"Red\" and Size \"L\") `fancyA/x~y~x` (for variant with Color \"Yellow\" and Size \"XL\")\n"
+"Note: make sure characters \"[,]\" do not appear in your attribute name"
+msgstr ""
+"Máscara de referencia para la construcción de referencias internas de una variante generada a partir de esta plantilla.\n"
+"Ejemplo:\n"
+"El producto llamado A con 2 atributos: tamaño y color:\n"
+"Producto: ABC\n"
+"Color: Rojo(Ro), Amarillo(Am), Negro(Ne)  #Rojo, Amarillo, Negro de atribulo valor, `Ro`, `Am`, `Ne` son el código correspondiente\n"
+"Tamaño: L (l), XL(x)\n"
+"Al configurar la máscara de referencia Variante de `[Color]-[Tamaño]`, el código predeterminado en las variantes será algo así como `Ro-l` `Ne-l` `Ro-x` ...\n"
+"Si lo desea, usted puede incluso tener el nombre del atributo aparece más de una vez en la máscara. Tal como , `fancyA/[Size]~[Color]~[Size]`Cuando se guarda, el código predeterminado en variantes será algo así como `fancyA/l~r~l` (para variante con Color \"Rojo\" y tamaño \"L\") `fancyA/x~y~x` (para variante con Color \"Amarillo\" y tamaño \"XL\")\n"
+"Nota: Asegúrese de caracteres \"[,]\" no aparecen en el nombre del atributo"
+
+#. module: product_variant_default_code
+#: field:product.template,reference_mask:0
+msgid "Variant reference mask"
+msgstr "Referencia máscara variante"
 

--- a/product_variant_default_code/i18n/product_variant_default_code.pot
+++ b/product_variant_default_code/i18n/product_variant_default_code.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-16 10:44+0000\n"
-"PO-Revision-Date: 2015-01-16 10:44+0000\n"
+"POT-Creation-Date: 2015-01-21 11:56+0000\n"
+"PO-Revision-Date: 2015-01-21 11:56+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,7 +21,7 @@ msgid "Attribute Code"
 msgstr ""
 
 #. module: product_variant_default_code
-#: code:addons/product_variant_default_code/models/product.py:147
+#: code:addons/product_variant_default_code/models/product.py:152
 #: sql_constraint:product.attribute:0
 #, python-format
 msgid "Attribute Name must be unique!"
@@ -37,6 +37,11 @@ msgstr ""
 #: code:addons/product_variant_default_code/models/product.py:48
 #, python-format
 msgid "Found unrecognized attribute name in \"Variant Reference Mask\""
+msgstr ""
+
+#. module: product_variant_default_code
+#: field:product.product,manual_code:0
+msgid "Manual code"
 msgstr ""
 
 #. module: product_variant_default_code

--- a/product_variant_default_code/i18n/product_variant_default_code.pot
+++ b/product_variant_default_code/i18n/product_variant_default_code.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-12 16:00+0000\n"
-"PO-Revision-Date: 2014-11-12 16:00+0000\n"
+"POT-Creation-Date: 2015-01-16 10:44+0000\n"
+"PO-Revision-Date: 2015-01-16 10:44+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,54 @@ msgid "Attribute Code"
 msgstr ""
 
 #. module: product_variant_default_code
-#: field:product.template,default_prefix:0
-msgid "Reference prefix"
+#: code:addons/product_variant_default_code/models/product.py:147
+#: sql_constraint:product.attribute:0
+#, python-format
+msgid "Attribute Name must be unique!"
 msgstr ""
 
 #. module: product_variant_default_code
-#: help:product.template,default_prefix:0
-msgid "Prefix for using when building internal references for the variants generated from this template"
+#: code:addons/product_variant_default_code/models/product.py:48
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: product_variant_default_code
+#: code:addons/product_variant_default_code/models/product.py:48
+#, python-format
+msgid "Found unrecognized attribute name in \"Variant Reference Mask\""
+msgstr ""
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_attribute
+msgid "Product Attribute"
+msgstr ""
+
+#. module: product_variant_default_code
+#: model:ir.model,name:product_variant_default_code.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: product_variant_default_code
+#: help:product.template,reference_mask:0
+msgid "Reference mask for building internal references of a variant generated from this template.\n"
+"Example:\n"
+"A product named ABC with 2 attributes: Size and Color:\n"
+"Product: ABC\n"
+"Color: Red(r), Yellow(y), Black(b)  #Red, Yellow, Black are the attribute value, `r`, `y`, `b` are the corresponding code\n"
+"Size: L (l), XL(x)\n"
+"When setting Variant reference mask to `[Color]-[Size]`, the default code on the variants will be something like `r-l` `b-l` `r-x` ...\n"
+"If you like, You can even have the attribute name appear more than once in the mask. Such as , `fancyA/[Size]~[Color]~[Size]` When saved, the default code on variants will be something like `fancyA/l~r~l` (for variant with Color \"Red\" and Size \"L\") `fancyA/x~y~x` (for variant with Color \"Yellow\" and Size \"XL\")\n"
+"Note: make sure characters \"[,]\" do not appear in your attribute name"
+msgstr ""
+
+#. module: product_variant_default_code
+#: field:product.template,reference_mask:0
+msgid "Variant reference mask"
 msgstr ""
 

--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -21,7 +21,7 @@ import re
 from string import Template
 from collections import defaultdict
 
-DEFAULT_REFERENCE_SEPERATOR = '-'
+DEFAULT_REFERENCE_SEPARATOR = '-'
 PLACE_HOLDER_4_MISSING_VALUE = '/'
 
 
@@ -99,7 +99,7 @@ class ProductTemplate(models.Model):
             attribute_names = []
             for line in product.attribute_line_ids:
                 attribute_names.append("[{}]".format(line.attribute_id.name))
-            default_mask = DEFAULT_REFERENCE_SEPERATOR.join(attribute_names)
+            default_mask = DEFAULT_REFERENCE_SEPARATOR.join(attribute_names)
             vals['reference_mask'] = default_mask
         elif vals.get('reference_mask'):
             sanitize_reference_mask(product, vals['reference_mask'])
@@ -114,14 +114,14 @@ class ProductTemplate(models.Model):
                 for line in self.attribute_line_ids:
                     attribute_names.append("[{}]".format(
                         line.attribute_id.name))
-                default_mask = DEFAULT_REFERENCE_SEPERATOR.join(
+                default_mask = DEFAULT_REFERENCE_SEPARATOR.join(
                     attribute_names)
                 vals['reference_mask'] = default_mask
         result = super(ProductTemplate, self).write(vals)
-        cond = [('product_tmpl_id', '=', self.id),
-                ('manual_code', '=', False)]
-        products = product_obj.search(cond)
         if vals.get('reference_mask'):
+            cond = [('product_tmpl_id', '=', self.id),
+                    ('manual_code', '=', False)]
+            products = product_obj.search(cond)
             for product in products:
                 render_default_code(product, product.reference_mask)
         return result
@@ -142,9 +142,7 @@ class ProductProduct(models.Model):
     @api.one
     @api.onchange('default_code')
     def onchange_default_code(self):
-        self.manual_code = False
-        if self.default_code:
-            self.manual_code = True
+        self.manual_code = bool(self.default_code)
 
 
 class ProductAttribute(models.Model):

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -12,5 +12,15 @@
                 </field>
             </field>
         </record>
+        <record id="product_normal_form_view_inh_variantdefaultcode" model="ir.ui.view">
+            <field name="name">product.normal.form.view.inh.variantdefaultcode</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <field name="default_code" position="before">
+                    <field name="manual_code" invisible="1"/>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/product_variant_default_code/views/product_view.xml
+++ b/product_variant_default_code/views/product_view.xml
@@ -18,7 +18,7 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="arch" type="xml">
                 <field name="default_code" position="before">
-                    <field name="manual_code" invisible="1"/>
+                    <field name="manual_code" />
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Se ha modificado este módulo, para realizar las siguiente modificaciones solicitadas por Ana:
1.- Se añade un check en product.product "código manual"
2.- Al modificar el campo default_code en product.product, automáticamente se marca "true" el campo código manual.
3.- El default code de todos los productos afectados se recalcula en el momento que se modifique un código de atributo de una plantilla, o bien cuando se modifique el prefijo de la plantilla.
4.-El proces NO actualiza aquellos productos marcados con "true" en el campo código manual
