### PR TITLE
[IMP] cambiar price_get de stock_move para cargar coste en el quant de producto finalizado

### DIFF
--- a/mrp_production_real_costs/models/stock_move.py
+++ b/mrp_production_real_costs/models/stock_move.py
@@ -141,3 +141,13 @@ class StockMove(models.Model):
                 # Write the standard price, as SUPERUSER_ID because a warehouse
                 # manager may not have the right to write on products
                 product.sudo().write({'standard_price': new_std_price})
+
+    @api.one
+    def get_unit_price(self):
+        analytic_line_obj = self.env['account.analytic.line']
+        res = super(StockMove, self).get_unit_price()
+        if self.production_id:
+            analytic_lines = analytic_line_obj.search(
+                    [('mrp_production_id', '=', self.production_id.id)])
+            res = sum([-line.amount for line in analytic_lines])
+        return res

--- a/mrp_production_real_costs/models/stock_move.py
+++ b/mrp_production_real_costs/models/stock_move.py
@@ -144,10 +144,10 @@ class StockMove(models.Model):
 
     @api.one
     def get_unit_price(self):
-        analytic_line_obj = self.env['account.analytic.line']
-        res = super(StockMove, self).get_unit_price()
         if self.production_id:
+            analytic_line_obj = self.env['account.analytic.line']
             analytic_lines = analytic_line_obj.search(
                 [('mrp_production_id', '=', self.production_id.id)])
-            res = sum([-line.amount for line in analytic_lines])
-        return res
+            return sum([-line.amount for line in analytic_lines])
+        else:
+            return super(StockMove, self).get_unit_price()

--- a/mrp_production_real_costs/models/stock_move.py
+++ b/mrp_production_real_costs/models/stock_move.py
@@ -148,6 +148,6 @@ class StockMove(models.Model):
         res = super(StockMove, self).get_unit_price()
         if self.production_id:
             analytic_lines = analytic_line_obj.search(
-                    [('mrp_production_id', '=', self.production_id.id)])
+                [('mrp_production_id', '=', self.production_id.id)])
             res = sum([-line.amount for line in analytic_lines])
         return res

--- a/mrp_production_real_costs/models/stock_move.py
+++ b/mrp_production_real_costs/models/stock_move.py
@@ -142,8 +142,9 @@ class StockMove(models.Model):
                 # manager may not have the right to write on products
                 product.sudo().write({'standard_price': new_std_price})
 
-    @api.one
+    @api.multi
     def get_unit_price(self):
+        self.ensure_one()
         if self.production_id:
             analytic_line_obj = self.env['account.analytic.line']
             analytic_lines = analytic_line_obj.search(


### PR DESCRIPTION
Aquí está la solicitud que me pidió ayer @anajuaristi 
Este módulo cambia la función price_get del objeto stock_move para que cuando se crea un quant para un producto finalizado de una OF se cargue el coste de dicha OF .
Para calcular el coste de una OF se suma el importe de las líneas analíticas creadas en costes reales. 
De todas formas, no estoy segura de que esto refleje realmente el coste de una OF en un momento determinado, por ello me gustaría que probara Ana este módulo, y me diga si realmente carga bien el coste que me ha solicitado, o si vamos a tener que cambiar el código. 
