### PR TITLE
[IMP] Cambios en costes estimados

### DIFF
--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -22,14 +22,16 @@ class MrpProduction(models.Model):
     _inherit = 'mrp.production'
 
     @api.one
-    @api.depends('analytic_line_ids', 'analytic_line_ids.estim_std_cost')
+    @api.depends('analytic_line_ids', 'analytic_line_ids.estim_std_cost',
+                 'product_qty')
     def get_unit_std_cost(self):
         self.std_cost = sum([line.estim_std_cost for line in
                              self.analytic_line_ids])
         self.unit_std_cost = self.std_cost / self.product_qty
 
     @api.one
-    @api.depends('analytic_line_ids', 'analytic_line_ids.estim_avg_cost')
+    @api.depends('analytic_line_ids', 'analytic_line_ids.estim_avg_cost',
+                 'product_qty')
     def get_unit_avg_cost(self):
         self.avg_cost = sum([line.estim_avg_cost for line in
                              self.analytic_line_ids])
@@ -51,13 +53,13 @@ class MrpProduction(models.Model):
     created_estimated_cost = fields.Integer(
         compute="_count_created_estimated_cost", string="Estimated Costs")
     std_cost = fields.Float(string="Estimated Standard Cost",
-                            compute="get_unit_std_cost", multi="std_cost")
+                            compute="get_unit_std_cost", store=True)
     avg_cost = fields.Float(string="Estimated Average Cost",
-                            compute="get_unit_avg_cost", multi="avg_cost")
+                            compute="get_unit_avg_cost", store=True)
     unit_std_cost = fields.Float(string="Estimated Standard Unit Cost",
-                                 compute="get_unit_std_cost", multi="std_cost")
+                                 compute="get_unit_std_cost", store=True)
     unit_avg_cost = fields.Float(string="Estimated Average Unit Cost",
-                                 compute="get_unit_avg_cost", multi="avg_cost")
+                                 compute="get_unit_avg_cost", store=True)
     product_manual_cost = fields.Float(
         string="Product Manual Cost",
         related="product_id.manual_standard_cost")

--- a/mrp_production_project_estimated_cost/views/mrp_production_view.xml
+++ b/mrp_production_project_estimated_cost/views/mrp_production_view.xml
@@ -23,7 +23,34 @@
                 </button>
                 <button name="action_cancel" position="after">
                     <button name="calculate_production_estimated_cost" states="draft,ready,in_production" string="Create Estimated Costs" type="object"/>
+                    <button name="load_product_std_price" string="Load Cost on Product" type="object" attrs="{'invisible':[('std_cost', '=', 0)]}"/>
                 </button>
+                <page string="Extra Information" position="inside">
+                    <group colspan="4" col="4">
+                        <group colspan="4" col="4" string="Manufacturing costs">
+                            <field name="std_cost" />
+                            <field name="unit_std_cost" />
+                            <field name="avg_cost" />
+                            <field name="unit_avg_cost" />
+                        </group>
+                    </group>
+                </page>
+                <xpath expr="//field[@name='product_uom']/.." position="after">
+                    <field name="product_cost"/>
+                    <field name="product_manual_cost"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="mrp_production_tree_view_inh_estimatedcost" model="ir.ui.view">
+            <field name="name">mrp.production.tree.view.inh.estimatedcost</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.mrp_production_tree_view"/>
+            <field name="arch" type="xml">
+                <field name="product_uom" position="after">
+                    <field name="product_cost"/>
+                    <field name="product_manual_cost"/>
+                </field>
             </field>
         </record>
 
@@ -76,36 +103,6 @@
 
         <menuitem action="mrp_fictitious_production_action" id="menu_mrp_fictitious_production_action"
             parent="mrp.menu_mrp_manufacturing" sequence="10"/>
-            
-        <record id="mrp.mrp_production_action" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('active','=',True)]</field>
-        </record>
-
-        <record id="mrp.mrp_production_action_planning" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('state','in',('ready','confirmed','in_production')),('active','=',True)]</field>
-        </record>
-
-        <record id="mrp.mrp_production_action2" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('state','=','ready'),('active','=',True)]</field>
-        </record>
-
-        <record id="mrp.mrp_production_action3" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('state','=','in_production'),('active','=',True)]</field>
-        </record>
-
-        <record id="mrp.mrp_production_action4" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('state','=','confirmed'),('active','=',True)]</field>
-        </record>
-
-        <record id="mrp.act_product_mrp_production" model="ir.actions.act_window">
-            <field name="context">{'active': True}</field>
-            <field name="domain">[('active','=',True)]</field>
-        </record>
 
     </data>
 </openerp>

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
@@ -2,7 +2,7 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from openerp import models, fields, api, exceptions, _
+from openerp import models, fields, api
 
 
 class WizCreateFictitiousOf(models.TransientModel):
@@ -10,30 +10,47 @@ class WizCreateFictitiousOf(models.TransientModel):
 
     date_planned = fields.Datetime(
         string='Scheduled Date', required=True, default=fields.Datetime.now())
+    load_on_product = fields.Boolean("Load cost on product")
 
     @api.multi
     def do_create_fictitious_of(self):
         production_obj = self.env['mrp.production']
         product_obj = self.env['product.product']
         self.ensure_one()
-        active_id = self._context['active_id']
-        active_model = self._context['active_model']
+        active_ids = self.env.context['active_ids']
+        active_model = self.env.context['active_model']
+        production_list = []
         if active_model == 'product.template':
-            cond = [('product_tmpl_id', '=', active_id)]
-            product = product_obj.search(cond)
-            if len(product) > 1:
-                raise exceptions.Warning(
-                    _('Error!: The product has variants'))
+            cond = [('product_tmpl_id', 'in', active_ids)]
+            product_list = product_obj.search(cond)
         else:
-            product = product_obj.browse(active_id)
-        vals = {'product_id': product.id,
-                'product_qty': 1,
-                'date_planned': self.date_planned,
-                'user_id': self._uid,
-                'location_src_id': production_obj._src_id_default(),
-                'location_dest_id': production_obj._dest_id_default(),
-                'active': False,
-                'product_uom': product.uom_id.id
+            product_list = product_obj.browse(active_ids)
+        for product in product_list:
+            vals = {'product_id': product.id,
+                    'product_template': product.product_tmpl_id.id,
+                    'product_qty': 1,
+                    'date_planned': self.date_planned,
+                    'user_id': self._uid,
+                    'location_src_id': production_obj._src_id_default(),
+                    'location_dest_id': production_obj._dest_id_default(),
+                    'active': False,
+                    'product_uom': product.uom_id.id
+                    }
+            new_production = production_obj.create(vals)
+            production_list.append(new_production.id)
+        if self.load_on_product:
+            for production_id in production_list:
+                try:
+                    production = production_obj.browse(production_id)
+                    production.action_compute()
+                    production.calculate_production_estimated_cost()
+                    production.load_product_std_price()
+                except:
+                    continue
+        return {'view_type': 'form',
+                'view_mode': 'tree,form',
+                'res_model': 'mrp.production',
+                'type': 'ir.actions.act_window',
+                'domain': "[('id','in'," + str(production_list) + "), "
+                "('active','=',False)]"
                 }
-        production_obj.create(vals)
-        return True

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
@@ -8,6 +8,7 @@
                 <form string="Create fictitius OF">
                     <group string="Create fictitious OF">
                         <field name="date_planned" />
+                        <field name="load_on_product" />
                     </group>
                     <footer>
                         <button name="do_create_fictitious_of" type="object" string="Create fictitius OF" class="oe_highlight" />
@@ -17,7 +18,7 @@
                 </form>
             </field>
         </record>
-         <record id="act_product_create_fictitious_of" model="ir.actions.act_window">
+        <record id="act_product_create_fictitious_of" model="ir.actions.act_window">
             <field name="name">Create fictitious OF</field>
             <field name="res_model">wiz.create.fictitious.of</field>
             <field name="view_type">form</field>
@@ -25,5 +26,19 @@
             <field name="view_id" ref="wiz_create_fictitious_of_view" />
             <field name="target">new</field>
         </record>
+        <act_window name="Create fictitious OF"
+            res_model="wiz.create.fictitious.of"
+            src_model="product.product"
+            view_mode="form"
+            target="new"
+            key2="client_action_multi"
+            id="action_run_create_fictitious_of"/>
+        <act_window name="Create fictitious OF"
+            res_model="wiz.create.fictitious.of"
+            src_model="product.template"
+            view_mode="form"
+            target="new"
+            key2="client_action_multi"
+            id="action_run_template_create_fictitious_of"/>
     </data>
 </openerp>

--- a/mrp_production_real_costs/__openerp__.py
+++ b/mrp_production_real_costs/__openerp__.py
@@ -37,7 +37,7 @@
             (Product stock * Product standard price + Production real cost) /
             (Product stock + Final product quantity)
         """,
-    'data': [],
+    'data': ["views/mrp_production_view.xml"],
     'demo': [],
     'installable': True,
     'auto_install': False,

--- a/mrp_production_real_costs/models/__init__.py
+++ b/mrp_production_real_costs/models/__init__.py
@@ -19,3 +19,4 @@
 from . import stock_move
 from . import mrp_production_workcenter_line
 from . import project_task_work
+from . import mrp_production

--- a/mrp_production_real_costs/models/mrp_production.py
+++ b/mrp_production_real_costs/models/mrp_production.py
@@ -24,16 +24,17 @@ class MrpProduction(models.Model):
     _inherit = 'mrp.production'
 
     @api.one
-    @api.depends('analytic_line_ids', 'analytic_line_ids.amount')
+    @api.depends('analytic_line_ids', 'analytic_line_ids.amount',
+                 'product_qty')
     def get_real_cost(self):
         self.real_cost = sum([-line.amount for line in
                              self.analytic_line_ids])
         self.unit_real_cost = self.real_cost / self.product_qty
 
     real_cost = fields.Float("Total Real Cost", compute="get_real_cost",
-                             multi="real_cost")
+                             store=True)
     unit_real_cost = fields.Float("Unit Real Cost", compute="get_real_cost",
-                                  multi="real_cost")
+                                  store=True)
 
     @api.multi
     def action_production_end(self):

--- a/mrp_production_real_costs/models/mrp_production.py
+++ b/mrp_production_real_costs/models/mrp_production.py
@@ -24,13 +24,16 @@ class MrpProduction(models.Model):
     _inherit = 'mrp.production'
 
     @api.one
-    @api.depends('real_cost', 'product_qty')
-    def get_unit_real_cost(self):
+    @api.depends('analytic_line_ids', 'analytic_line_ids.amount')
+    def get_real_cost(self):
+        self.real_cost = sum([-line.amount for line in
+                             self.analytic_line_ids])
         self.unit_real_cost = self.real_cost / self.product_qty
 
-    real_cost = fields.Float("Total Real Cost")
-    unit_real_cost = fields.Float("Unit Real Cost",
-                                  compute="get_unit_real_cost")
+    real_cost = fields.Float("Total Real Cost", compute="get_real_cost",
+                             multi="real_cost")
+    unit_real_cost = fields.Float("Unit Real Cost", compute="get_real_cost",
+                                  multi="real_cost")
 
     @api.multi
     def action_production_end(self):

--- a/mrp_production_real_costs/models/mrp_production.py
+++ b/mrp_production_real_costs/models/mrp_production.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class MrpProduction(models.Model):
+
+    _inherit = 'mrp.production'
+
+    @api.one
+    @api.depends('real_cost', 'product_qty')
+    def get_unit_real_cost(self):
+        self.unit_real_cost = self.real_cost / self.product_qty
+
+    real_cost = fields.Float("Total Real Cost")
+    unit_real_cost = fields.Float("Unit Real Cost",
+                                  compute="get_unit_real_cost")
+
+    @api.multi
+    def action_production_end(self):
+        res = super(MrpProduction, self).action_production_end()
+        analytic_line_obj = self.env['account.analytic.line']
+        for record in self:
+            cost_lines = analytic_line_obj.search([('mrp_production_id', '=',
+                                                    record.id)])
+            record.real_cost = sum([-line.amount for line in cost_lines])
+        return res

--- a/mrp_production_real_costs/views/mrp_production_view.xml
+++ b/mrp_production_real_costs/views/mrp_production_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="mrp_production_project_form_view_inh_estimatedcost" model="ir.ui.view">
+            <field name="name">mrp.production.project.form.view.inh.estimatedcost</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost"/>
+            <field name="arch" type="xml">
+                <field name="unit_avg_cost" position="after">
+                    <field name="real_cost" attrs="{'invisible': [('state', '!=', 'done')]}"/>
+                    <field name="unit_real_cost" attrs="{'invisible': [('state', '!=', 'done')]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Se solicitan en la sesión de hoy sobre costes, para terminar de fijar los requerimientos de Disna:
1. Desde la ficha de producto se permite lanzar Ofs simuladas, pero producto por producto. Se solicita que se puedan lanzar desde el listado para varios o para un grupo, para lo que seleccione el usuario mediante agrupación por un campo determinado o cualquier criterio (en principio, utilizarán los extra categories para agrupar)
2. El Wizard de lanzamiento preguntará, con un check si se quiere "actualizar el dato en la ficha de producto" o no. Si se clicka --> Una vez calculados los costes estimados del producto el valor sumatorio unitario total obtenido en el campo "standar" de las líneas de analítica, actualizará el campo "standar" de la ficha de producto "machacando" el que había anteriormente. (CUIDADO, el campo PMP de la ficha de producto NO SE DEBE CAMBIAR, solo el manual)
El orden de lanzamiento del wizard lo controlará Gonzalo. Deberán ir calculando del nivel inferior al superior, dentro de la selección. 
3. El valor sumatorio total calculado en analítica, se mostrará visible en la OF para los campos standar y Pmp... (related a la suma de costes de la OF) -->Añado cosecha propia... podriamos mostrar el total y el unitario por producto, que es el que se llevará a la ficha. Es decir, si lanzo la OF por 2000 unidades, ver el total completo de la OF que es lo que nos dará analítica, pero mostrar también el unitario que será el de la OF / número de unidades que es lo que actualizará la ficha de producto.
4. Tanto en LMs como en OFs, mostrar related al producto los 2 campos de coste, el standar y el PMP, tanto en los componentes como en el producto final, y mostrarlos en las listas Tree de ambos objetos.

Los primeros 3 puntos están desarrollados y se suben en este PR. En cambio al hacer el punto 4 me he encontrado con un tema que creo que deberíamos de comentarlo. Como bien sabéis no existe una viste tree para las listas de materiales. Pero si que tenemos un módulo en odoomrp-wip, que nos crea una vista tree. He intentado meter los dos campos en ese modulo, que se llama mrp_bom_state, pero no puedo ponerlos ahí, ya que el campo manual_standard_cost de la ficha del producto se crea en el módulo de costes estimados y el módulo de bom no tiene dependencia con esto. Que solución me proponéis? 
