### PR TITLE
[IMP] añadir proyecto en asistente de crear OF ficticias + cargar LdM en asistente de OF ficticias

### DIFF
--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
@@ -42,7 +42,7 @@ class WizCreateFictitiousOf(models.TransientModel):
             new_production.action_compute()
             production_list.append(new_production.id)
         if self.load_on_product:
-            for production in production_list:
+            for production_id in production_list:
                 try:
                     production = production_obj.browse(production_id)
                     production.calculate_production_estimated_cost()

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
@@ -11,6 +11,7 @@ class WizCreateFictitiousOf(models.TransientModel):
     date_planned = fields.Datetime(
         string='Scheduled Date', required=True, default=fields.Datetime.now())
     load_on_product = fields.Boolean("Load cost on product")
+    project_id = fields.Many2one("project.project", string="Project")
 
     @api.multi
     def do_create_fictitious_of(self):
@@ -34,15 +35,16 @@ class WizCreateFictitiousOf(models.TransientModel):
                     'location_src_id': production_obj._src_id_default(),
                     'location_dest_id': production_obj._dest_id_default(),
                     'active': False,
-                    'product_uom': product.uom_id.id
+                    'product_uom': product.uom_id.id,
+                    'project_id': self.project_id.id
                     }
             new_production = production_obj.create(vals)
+            new_production.action_compute()
             production_list.append(new_production.id)
         if self.load_on_product:
-            for production_id in production_list:
+            for production in production_list:
                 try:
                     production = production_obj.browse(production_id)
-                    production.action_compute()
                     production.calculate_production_estimated_cost()
                     production.load_product_std_price()
                 except:

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
@@ -9,6 +9,7 @@
                     <group string="Create fictitious OF">
                         <field name="date_planned" />
                         <field name="load_on_product" />
+                        <field name="project_id" />
                     </group>
                     <footer>
                         <button name="do_create_fictitious_of" type="object" string="Create fictitius OF" class="oe_highlight" />


### PR DESCRIPTION
Durante una reunión con Ana esta tarde, me ha comentado que no carga la lista de materiales en las ofs, y que añadiese un proyecto en el asistente para asignar posteriormente a todas las ofs ficticias que se creen.
En este PR están los cambios que menciono.
