### PR TITLE
[FIX] call super before testing the workcenters

### DIFF
--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -24,11 +24,12 @@ class MrpProduction(models.Model):
 
     @api.multi
     def action_confirm(self):
+        res = super(MrpProduction, self).action_confirm()
         if (self.routing_id and
                 not any([x.do_production for x in self.workcenter_lines])):
             raise exceptions.Warning(
                 _("At least one work order must have checked 'Produce here'"))
-        return super(MrpProduction, self).action_confirm()
+        return res
 
     @api.multi
     def _action_compute_lines(self, properties=None):


### PR DESCRIPTION
We check that the production order's workcenter lines contain at least
one "Produce here" line", but at this stage they are not created because
we didn't call super().
So let's call super() first.
