### PR TITLE
[IMP] mrp_production_project_estimated_cost: quitar warning imputacion costes de maquina

### DIFF
--- a/mrp_production_project_estimated_cost/README.rst
+++ b/mrp_production_project_estimated_cost/README.rst
@@ -16,9 +16,9 @@ and the other per cycle cost.
 
 It has also created the new menu option "Fictitious Manufacturing Orders to
 estimate costs". When a new MO is created and the new field "active" is equal
-to false, the OF will be considered as a fictional MO, what with can not be
+to false, the MO will be considered as a fictional MO, what with can not be
 confirmed, and only is valid to estimate costs. To estimate costs will have to
 press the "Compute data" button in tab "Work Orders". These fictitious MO will
 have a different sequence.
-From the product form may create a fictitious OF.
+From the product form may create a fictitious MO.
 

--- a/mrp_production_project_estimated_cost/i18n/es.po
+++ b/mrp_production_project_estimated_cost/i18n/es.po
@@ -101,11 +101,6 @@ msgid "Create fictitious MO"
 msgstr "CrearOF ficticia"
 
 #. module: mrp_production_project_estimated_cost
-#: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitious MO"
-msgstr "Crear OF ficticia"
-
-#. module: mrp_production_project_estimated_cost
 #: field:wiz.create.fictitious.of,create_uid:0
 msgid "Created by"
 msgstr "Creado por"
@@ -127,15 +122,6 @@ msgstr "Costes estim."
 
 #. module: mrp_production_project_estimated_cost
 #: field:account.analytic.line,estim_avg_cost:0
-msgid "Estimate Average Cost"
-msgstr "Coste medio estimado"
-
-#. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_std_cost:0
-msgid "Estimate Standard Cost"
-msgstr "Coste estándar estimado"
-
-#. module: mrp_production_project_estimated_cost
 #: field:mrp.production,avg_cost:0
 msgid "Estimated Average Cost"
 msgstr "Coste medio estimado"
@@ -151,6 +137,7 @@ msgid "Estimated Costs"
 msgstr "Costes estimados"
 
 #. module: mrp_production_project_estimated_cost
+#: field:account.analytic.line,estim_std_cost:0
 #: field:mrp.production,std_cost:0
 msgid "Estimated Standard Cost"
 msgstr "Coste estándar estimado"

--- a/mrp_production_project_estimated_cost/i18n/es.po
+++ b/mrp_production_project_estimated_cost/i18n/es.po
@@ -89,7 +89,7 @@ msgstr "Crear costes estimados"
 #. module: mrp_production_project_estimated_cost
 #: view:product.product:mrp_production_project_estimated_cost.product_product_form_view_bom_button_inh_estimatedcost
 #: view:product.template:mrp_production_project_estimated_cost.product_template_form_view_bom_button_inh_estimatedcost
-msgid "Create Fictitious OF"
+msgid "Create Fictitious MO"
 msgstr "Crea OF ficticia"
 
 #. module: mrp_production_project_estimated_cost
@@ -97,12 +97,12 @@ msgstr "Crea OF ficticia"
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_create_fictitious_of
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_template_create_fictitious_of
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitious OF"
+msgid "Create fictitious MO"
 msgstr "CrearOF ficticia"
 
 #. module: mrp_production_project_estimated_cost
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitius OF"
+msgid "Create fictitious MO"
 msgstr "Crear OF ficticia"
 
 #. module: mrp_production_project_estimated_cost
@@ -133,7 +133,7 @@ msgstr "Coste medio estimado"
 #. module: mrp_production_project_estimated_cost
 #: field:account.analytic.line,estim_std_cost:0
 msgid "Estimate Standard Cost"
-msgstr "Coste estandar estimado"
+msgstr "Coste estándar estimado"
 
 #. module: mrp_production_project_estimated_cost
 #: field:mrp.production,avg_cost:0
@@ -153,12 +153,12 @@ msgstr "Costes estimados"
 #. module: mrp_production_project_estimated_cost
 #: field:mrp.production,std_cost:0
 msgid "Estimated Standard Cost"
-msgstr "Coste estandar estimado"
+msgstr "Coste estándar estimado"
 
 #. module: mrp_production_project_estimated_cost
 #: field:mrp.production,unit_std_cost:0
 msgid "Estimated Standard Unit Cost"
-msgstr "Coste estandar estimado por unidad"
+msgstr "Coste estándar estimado por unidad"
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_estimated_costs_per_production
@@ -209,7 +209,7 @@ msgstr "Cargar coste en el producto"
 #. module: mrp_production_project_estimated_cost
 #: field:product.template,manual_standard_cost:0
 msgid "Manual Standard Cost"
-msgstr "Coste estandar manual"
+msgstr "Coste estándar manual"
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.model,name:mrp_production_project_estimated_cost.model_mrp_production
@@ -260,7 +260,7 @@ msgstr "Esta máquina no tiene un producto asignado: %s"
 #: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:257
 #, python-format
 msgid "You must define Income account in the product \"%s\", or in the product category"
-msgstr "Debe de definir la cuenta de entrada en el producto \"%s\", o en la categoría del producto"
+msgstr "Debe definir la cuenta de entrada en el producto \"%s\", o en la categoría del producto"
 
 #. module: mrp_production_project_estimated_cost
 #: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:261

--- a/mrp_production_project_estimated_cost/i18n/es.po
+++ b/mrp_production_project_estimated_cost/i18n/es.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-23 11:57+0000\n"
-"PO-Revision-Date: 2015-01-23 12:58+0100\n"
-"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"POT-Creation-Date: 2015-02-24 15:19+0000\n"
+"PO-Revision-Date: 2015-02-24 16:25+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -16,37 +16,37 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:74
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:165
 #, python-format
 msgid "%s-%s"
 msgstr "%s-%s"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:102
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:187
 #, python-format
 msgid "%s-%s Post-operation"
 msgstr "%s-%s Post-operación"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:93
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:178
 #, python-format
 msgid "%s-%s Pre-operation"
 msgstr "%s-%s Pre-operación"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:131
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:238
 #, python-format
 msgid "%s-%s-%s"
 msgstr "%s-%s-%s"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:112
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:200
 #, python-format
 msgid "%s-%s-C-%s"
 msgstr "%s-%s-C-%s"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:120
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:215
 #, python-format
 msgid "%s-%s-H-%s"
 msgstr "%s-%s-H-%s"
@@ -62,9 +62,29 @@ msgid "Analytic Line"
 msgstr "Línea analítica"
 
 #. module: mrp_production_project_estimated_cost
+#: field:project.project,automatic_creation:0
+msgid "Automatic Creation"
+msgstr "Creación automática"
+
+#. module: mrp_production_project_estimated_cost
+#: model:ir.model,name:mrp_production_project_estimated_cost.model_mrp_bom
+msgid "Bill of Material"
+msgstr "Lista de material"
+
+#. module: mrp_production_project_estimated_cost
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
 msgid "Cancel"
 msgstr "Cancelar"
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,analytic_line_ids:0
+msgid "Cost Lines"
+msgstr "Líneas de costes"
+
+#. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Create Estimated Costs"
+msgstr "Crear costes estimados"
 
 #. module: mrp_production_project_estimated_cost
 #: view:product.product:mrp_production_project_estimated_cost.product_product_form_view_bom_button_inh_estimatedcost
@@ -74,6 +94,8 @@ msgstr "Crea OF ficticia"
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.act_product_create_fictitious_of
+#: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_create_fictitious_of
+#: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_template_create_fictitious_of
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
 msgid "Create fictitious OF"
 msgstr "CrearOF ficticia"
@@ -94,30 +116,59 @@ msgid "Created on"
 msgstr "Creado el"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py:26
-#, python-format
-msgid "Error!: The product has variants"
-msgstr "Error!: El producto tiene variantes"
+#: field:mrp.production,partner:0
+msgid "Customer"
+msgstr "Cliente"
 
 #. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_average_cost:0
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_buttons_inh_estimatedcost
+msgid "Estim. Costs"
+msgstr "Costes estim."
+
+#. module: mrp_production_project_estimated_cost
+#: field:account.analytic.line,estim_avg_cost:0
 msgid "Estimate Average Cost"
 msgstr "Coste medio estimado"
 
 #. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_standard_cost:0
+#: field:account.analytic.line,estim_std_cost:0
 msgid "Estimate Standard Cost"
-msgstr "Coste estandard estimado"
+msgstr "Coste estandar estimado"
 
 #. module: mrp_production_project_estimated_cost
-#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_buttons_inh_estimatedcost
-msgid "Estimated costs"
+#: field:mrp.production,avg_cost:0
+msgid "Estimated Average Cost"
+msgstr "Coste medio estimado"
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,unit_avg_cost:0
+msgid "Estimated Average Unit Cost"
+msgstr "Coste medio estimado por unidad"
+
+#. module: mrp_production_project_estimated_cost
+#: view:account.analytic.line:mrp_production_project_estimated_cost.estimated_cost_list_view
+msgid "Estimated Costs"
 msgstr "Costes estimados"
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,std_cost:0
+msgid "Estimated Standard Cost"
+msgstr "Coste estandar estimado"
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,unit_std_cost:0
+msgid "Estimated Standard Unit Cost"
+msgstr "Coste estandar estimado por unidad"
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_estimated_costs_per_production
 msgid "Estimated costs from production order"
 msgstr "Costes estimados desde orden de producción"
+
+#. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Extra Information"
+msgstr "Información extra"
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.mrp_fictitious_production_action
@@ -146,6 +197,16 @@ msgid "Last Updated on"
 msgstr "Última actualización el"
 
 #. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Load Cost on Product"
+msgstr "Cargar coste en el producto"
+
+#. module: mrp_production_project_estimated_cost
+#: field:wiz.create.fictitious.of,load_on_product:0
+msgid "Load cost on product"
+msgstr "Cargar coste en el producto"
+
+#. module: mrp_production_project_estimated_cost
 #: field:product.template,manual_standard_cost:0
 msgid "Manual Standard Cost"
 msgstr "Coste estandar manual"
@@ -156,6 +217,17 @@ msgid "Manufacturing Order"
 msgstr "Órden de producción"
 
 #. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Manufacturing costs"
+msgstr "Costes de fabricación"
+
+#. module: mrp_production_project_estimated_cost
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:164
+#, python-format
+msgid "One consume line has no product assigned."
+msgstr "Una de las líneas de consumo no tiene producto asignado."
+
+#. module: mrp_production_project_estimated_cost
 #: model:ir.model,name:mrp_production_project_estimated_cost.model_product_template
 msgid "Product Template"
 msgstr "Plantilla de producto"
@@ -163,7 +235,13 @@ msgstr "Plantilla de producto"
 #. module: mrp_production_project_estimated_cost
 #: view:account.analytic.line:mrp_production_project_estimated_cost.view_account_analytic_line_form_inh_estimatedcost
 msgid "Production Information"
-msgstr "Production Information"
+msgstr "Información de la fabricación"
+
+#. module: mrp_production_project_estimated_cost
+#: model:ir.model,name:mrp_production_project_estimated_cost.model_project_project
+#: field:wiz.create.fictitious.of,project_id:0
+msgid "Project"
+msgstr "Proyecto"
 
 #. module: mrp_production_project_estimated_cost
 #: field:wiz.create.fictitious.of,date_planned:0
@@ -171,13 +249,21 @@ msgid "Scheduled Date"
 msgstr "Fecha programada"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:151
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:198
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:213
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:233
+#, python-format
+msgid "There is at least this workcenter without product: %s"
+msgstr "Esta máquina no tiene un producto asignado: %s"
+
+#. module: mrp_production_project_estimated_cost
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:257
 #, python-format
 msgid "You must define Income account in the product \"%s\", or in the product category"
 msgstr "Debe de definir la cuenta de entrada en el producto \"%s\", o en la categoría del producto"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:155
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:261
 #, python-format
 msgid "You must define one Analytic Account for this MO: %s"
 msgstr "Debe definir una cuenta analítica para esta MO: %s"
@@ -185,7 +271,7 @@ msgstr "Debe definir una cuenta analítica para esta MO: %s"
 #. module: mrp_production_project_estimated_cost
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
 msgid "or"
-msgstr "or"
+msgstr "o"
 
 #. module: mrp_production_project_estimated_cost
 #: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost

--- a/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
+++ b/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-23 11:56+0000\n"
-"PO-Revision-Date: 2015-01-23 11:56+0000\n"
+"POT-Creation-Date: 2015-02-24 15:18+0000\n"
+"PO-Revision-Date: 2015-02-24 15:18+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,37 +16,37 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:74
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:165
 #, python-format
 msgid "%s-%s"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:102
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:187
 #, python-format
 msgid "%s-%s Post-operation"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:93
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:178
 #, python-format
 msgid "%s-%s Pre-operation"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:131
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:238
 #, python-format
 msgid "%s-%s-%s"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:112
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:200
 #, python-format
 msgid "%s-%s-C-%s"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:120
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:215
 #, python-format
 msgid "%s-%s-H-%s"
 msgstr ""
@@ -62,8 +62,28 @@ msgid "Analytic Line"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
+#: field:project.project,automatic_creation:0
+msgid "Automatic Creation"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: model:ir.model,name:mrp_production_project_estimated_cost.model_mrp_bom
+msgid "Bill of Material"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
 msgid "Cancel"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,analytic_line_ids:0
+msgid "Cost Lines"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Create Estimated Costs"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
@@ -74,6 +94,8 @@ msgstr ""
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.act_product_create_fictitious_of
+#: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_create_fictitious_of
+#: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_template_create_fictitious_of
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
 msgid "Create fictitious OF"
 msgstr ""
@@ -94,29 +116,58 @@ msgid "Created on"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py:26
-#, python-format
-msgid "Error!: The product has variants"
-msgstr ""
-
-#. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_average_cost:0
-msgid "Estimate Average Cost"
-msgstr ""
-
-#. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_standard_cost:0
-msgid "Estimate Standard Cost"
+#: field:mrp.production,partner:0
+msgid "Customer"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
 #: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_buttons_inh_estimatedcost
-msgid "Estimated costs"
+msgid "Estim. Costs"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:account.analytic.line,estim_avg_cost:0
+msgid "Estimate Average Cost"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:account.analytic.line,estim_std_cost:0
+msgid "Estimate Standard Cost"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,avg_cost:0
+msgid "Estimated Average Cost"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,unit_avg_cost:0
+msgid "Estimated Average Unit Cost"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: view:account.analytic.line:mrp_production_project_estimated_cost.estimated_cost_list_view
+msgid "Estimated Costs"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,std_cost:0
+msgid "Estimated Standard Cost"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:mrp.production,unit_std_cost:0
+msgid "Estimated Standard Unit Cost"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_estimated_costs_per_production
 msgid "Estimated costs from production order"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Extra Information"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
@@ -146,6 +197,16 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Load Cost on Product"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: field:wiz.create.fictitious.of,load_on_product:0
+msgid "Load cost on product"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
 #: field:product.template,manual_standard_cost:0
 msgid "Manual Standard Cost"
 msgstr ""
@@ -153,6 +214,17 @@ msgstr ""
 #. module: mrp_production_project_estimated_cost
 #: model:ir.model,name:mrp_production_project_estimated_cost.model_mrp_production
 msgid "Manufacturing Order"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: view:mrp.production:mrp_production_project_estimated_cost.mrp_production_form_view_inh_estimatedcost
+msgid "Manufacturing costs"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:164
+#, python-format
+msgid "One consume line has no product assigned."
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
@@ -166,18 +238,32 @@ msgid "Production Information"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
+#: model:ir.model,name:mrp_production_project_estimated_cost.model_project_project
+#: field:wiz.create.fictitious.of,project_id:0
+msgid "Project"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
 #: field:wiz.create.fictitious.of,date_planned:0
 msgid "Scheduled Date"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:151
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:198
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:213
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:233
+#, python-format
+msgid "There is at least this workcenter without product: %s"
+msgstr ""
+
+#. module: mrp_production_project_estimated_cost
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:257
 #, python-format
 msgid "You must define Income account in the product \"%s\", or in the product category"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:155
+#: code:addons/mrp_production_project_estimated_cost/models/mrp_production.py:261
 #, python-format
 msgid "You must define one Analytic Account for this MO: %s"
 msgstr ""

--- a/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
+++ b/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
@@ -89,7 +89,7 @@ msgstr ""
 #. module: mrp_production_project_estimated_cost
 #: view:product.product:mrp_production_project_estimated_cost.product_product_form_view_bom_button_inh_estimatedcost
 #: view:product.template:mrp_production_project_estimated_cost.product_template_form_view_bom_button_inh_estimatedcost
-msgid "Create Fictitious OF"
+msgid "Create Fictitious MO"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
@@ -97,12 +97,12 @@ msgstr ""
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_create_fictitious_of
 #: model:ir.actions.act_window,name:mrp_production_project_estimated_cost.action_run_template_create_fictitious_of
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitious OF"
+msgid "Create fictitious MO"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
 #: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitius OF"
+msgid "Create fictitious MO"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost

--- a/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
+++ b/mrp_production_project_estimated_cost/i18n/mrp_production_project_estimated_cost.pot
@@ -101,11 +101,6 @@ msgid "Create fictitious MO"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
-#: view:wiz.create.fictitious.of:mrp_production_project_estimated_cost.wiz_create_fictitious_of_view
-msgid "Create fictitious MO"
-msgstr ""
-
-#. module: mrp_production_project_estimated_cost
 #: field:wiz.create.fictitious.of,create_uid:0
 msgid "Created by"
 msgstr ""
@@ -127,15 +122,6 @@ msgstr ""
 
 #. module: mrp_production_project_estimated_cost
 #: field:account.analytic.line,estim_avg_cost:0
-msgid "Estimate Average Cost"
-msgstr ""
-
-#. module: mrp_production_project_estimated_cost
-#: field:account.analytic.line,estim_std_cost:0
-msgid "Estimate Standard Cost"
-msgstr ""
-
-#. module: mrp_production_project_estimated_cost
 #: field:mrp.production,avg_cost:0
 msgid "Estimated Average Cost"
 msgstr ""
@@ -151,6 +137,7 @@ msgid "Estimated Costs"
 msgstr ""
 
 #. module: mrp_production_project_estimated_cost
+#: field:account.analytic.line,estim_std_cost:0
 #: field:mrp.production,std_cost:0
 msgid "Estimated Standard Cost"
 msgstr ""

--- a/mrp_production_project_estimated_cost/models/account_analytic_line.py
+++ b/mrp_production_project_estimated_cost/models/account_analytic_line.py
@@ -22,7 +22,7 @@ import openerp.addons.decimal_precision as dp
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
-    estim_std_cost = fields.Float(string='Estimate Standard Cost',
+    estim_std_cost = fields.Float(string='Estimated Standard Cost',
                                   digits=dp.get_precision('Product Price'))
-    estim_avg_cost = fields.Float(string='Estimate Average Cost',
+    estim_avg_cost = fields.Float(string='Estimated Average Cost',
                                   digits=dp.get_precision('Product Price'))

--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -225,8 +225,9 @@ class MrpProduction(models.Model):
                              line.workcenter_id.product_id.name))
                     vals = record._prepare_estim_cost_analytic_line(
                         journal_wk, name, record, line,
-                        line.workcenter_id.product_id, wc.op_number)
-                    vals['estim_avg_cost'] = wc.op_number * wc.op_avg_cost
+                        line.workcenter_id.product_id, wc.hour)
+                    vals['estim_avg_cost'] = (wc.op_number * wc.op_avg_cost *
+                                              wc.hour)
                     vals['estim_std_cost'] = vals['estim_avg_cost']
                     analytic_line_obj.create(vals)
 

--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -195,7 +195,7 @@ class MrpProduction(models.Model):
                 if line.cycle:
                     if not line.workcenter_id.product_id:
                         raise exceptions.Warning(
-                            _("There is at least one workcenter without "
+                            _("There is at least this workcenter without "
                               "product: %s") % line.workcenter_id.name)
                     name = (_('%s-%s-C-%s') %
                             (record.name, line.routing_wc_line.operation.code,
@@ -210,7 +210,7 @@ class MrpProduction(models.Model):
                 if line.hour:
                     if not line.workcenter_id.product_id:
                         raise exceptions.Warning(
-                            _("There is at least one workcenter without "
+                            _("There is at least this workcenter without "
                               "product: %s") % line.workcenter_id.name)
                     name = (_('%s-%s-H-%s') %
                             (record.name, line.routing_wc_line.operation.code,
@@ -230,7 +230,7 @@ class MrpProduction(models.Model):
                 if wc.op_number > 0:
                     if not line.workcenter_id.product_id:
                         raise exceptions.Warning(
-                            _("There is at least one workcenter without "
+                            _("There is at least this workcenter without "
                               "product: %s") % line.workcenter_id.name)
                     journal_wk = record.env.ref(
                         'mrp_production_project_estimated_cost.analytic_'

--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -189,7 +189,7 @@ class MrpProduction(models.Model):
                     amount = line.workcenter_id.post_op_product.standard_price
                     vals['amount'] = amount
                     analytic_line_obj.create(vals)
-                if line.cycle:
+                if line.cycle and line.workcenter_id.product_id:
                     name = (_('%s-%s-C-%s') %
                             (record.name, line.routing_wc_line.operation.code,
                              line.workcenter_id.name))
@@ -200,7 +200,7 @@ class MrpProduction(models.Model):
                     vals['estim_avg_cost'] = line.cycle * cost
                     vals['estim_std_cost'] = vals['estim_avg_cost']
                     analytic_line_obj.create(vals)
-                if line.hour:
+                if line.hour and line.workcenter_id.product_id:
                     name = (_('%s-%s-H-%s') %
                             (record.name, line.routing_wc_line.operation.code,
                              line.workcenter_id.name))
@@ -216,7 +216,7 @@ class MrpProduction(models.Model):
                     vals['estim_avg_cost'] = hour * cost
                     vals['estim_std_cost'] = vals['estim_avg_cost']
                     analytic_line_obj.create(vals)
-                if wc.op_number > 0:
+                if wc.op_number > 0 and line.workcenter_id.product_id:
                     journal_wk = record.env.ref(
                         'mrp_production_project_estimated_cost.analytic_'
                         'journal_operators', False)

--- a/mrp_production_project_estimated_cost/views/product_view.xml
+++ b/mrp_production_project_estimated_cost/views/product_view.xml
@@ -19,7 +19,7 @@
                  <button name="action_view_bom" position="after">
                     <button class="oe_inline oe_stat_button" 
                         name="%(act_product_create_fictitious_of)d" 
-                        string="Create Fictitious OF" type="action"
+                        string="Create Fictitious MO" type="action"
                         attrs="{'invisible':[('type', '=', 'service')]}" icon="fa-flask" />
                  </button>
             </field>
@@ -32,7 +32,7 @@
                  <button name="action_view_mos" position="before">
                     <button class="oe_inline oe_stat_button" 
                         name="%(act_product_create_fictitious_of)d" 
-                        string="Create Fictitious OF" type="action"
+                        string="Create Fictitious MO" type="action"
                         attrs="{'invisible':[('type', '=', 'service')]}" icon="fa-flask" />
                  </button>
             </field>

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of_view.xml
@@ -5,14 +5,14 @@
             <field name="name">wiz.create.fictitious.of.view</field>
             <field name="model">wiz.create.fictitious.of</field>
             <field name="arch" type="xml">
-                <form string="Create fictitius OF">
-                    <group string="Create fictitious OF">
+                <form string="Create fictitious MO">
+                    <group string="Create fictitious MO">
                         <field name="date_planned" />
                         <field name="load_on_product" />
                         <field name="project_id" />
                     </group>
                     <footer>
-                        <button name="do_create_fictitious_of" type="object" string="Create fictitius OF" class="oe_highlight" />
+                        <button name="do_create_fictitious_of" type="object" string="Create fictitius MO" class="oe_highlight" />
                         or
                         <button string="Cancel" class="oe_link" special="cancel" />
                     </footer>
@@ -20,21 +20,21 @@
             </field>
         </record>
         <record id="act_product_create_fictitious_of" model="ir.actions.act_window">
-            <field name="name">Create fictitious OF</field>
+            <field name="name">Create fictitious MO</field>
             <field name="res_model">wiz.create.fictitious.of</field>
             <field name="view_type">form</field>
             <field name="view_mode">form</field>
             <field name="view_id" ref="wiz_create_fictitious_of_view" />
             <field name="target">new</field>
         </record>
-        <act_window name="Create fictitious OF"
+        <act_window name="Create fictitious MO"
             res_model="wiz.create.fictitious.of"
             src_model="product.product"
             view_mode="form"
             target="new"
             key2="client_action_multi"
             id="action_run_create_fictitious_of"/>
-        <act_window name="Create fictitious OF"
+        <act_window name="Create fictitious MO"
             res_model="wiz.create.fictitious.of"
             src_model="product.template"
             view_mode="form"


### PR DESCRIPTION
Se salta el warning y no se crea línea analítica cuando un workcenter no tiene producto asignado.
