### PR TITLE
changed wording to "Secondary Unit of Purchase"

### DIFF
--- a/purchase_secondary_unit/models/product.py
+++ b/purchase_secondary_unit/models/product.py
@@ -26,10 +26,10 @@ class ProductTemplate(models.Model):
     uop_id = fields.Many2one(
         comodel_name='product.uom', string='Secondary Unit of Purchase',
         help='Specify a unit of measure here if purchasing is made in another'
-        ' unit of measure category than inventory. Keep empty to use the default unit'
-        ' of measure.')
+        ' unit of measure category than inventory. Keep empty to use the'
+        ' default unit of measure.')
     uop_coeff = fields.Float(
         string='Purchase Unit of Measure -> 2UoP Coeff',
         digits=dp.get_precision('Product UoP'),
-        help='Coefficient to convert default Purchase Unit of Measure to Secondary Unit'
-        ' of Purchase\n uop = uom * coeff', default=1.0)
+        help='Coefficient to convert default Purchase Unit of Measure to'
+        ' Secondary Unit of Purchase\n uop = uom * coeff', default=1.0)

--- a/purchase_secondary_unit/models/product.py
+++ b/purchase_secondary_unit/models/product.py
@@ -24,12 +24,12 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     uop_id = fields.Many2one(
-        comodel_name='product.uom', string='Unit of Purchase',
+        comodel_name='product.uom', string='Secondary Unit of Purchase',
         help='Specify a unit of measure here if purchasing is made in another'
-        ' unit of measure than inventory. Keep empty to use the default unit'
+        ' unit of measure category than inventory. Keep empty to use the default unit'
         ' of measure.')
     uop_coeff = fields.Float(
-        string='Purchase Unit of Measure -> UoP Coeff',
+        string='Purchase Unit of Measure -> 2UoP Coeff',
         digits=dp.get_precision('Product UoP'),
-        help='Coefficient to convert default Purchase Unit of Measure to Unit'
+        help='Coefficient to convert default Purchase Unit of Measure to Secondary Unit'
         ' of Purchase\n uop = uom * coeff', default=1.0)


### PR DESCRIPTION
original wording "Unit of Purchase" results into fields 
- Purchase Unit of Measure    (from   product.template)   &
- Unit of Purchase   &
  appearing in the "procurement" tab in the products from view

I think it differentiates a little clearer between those 2 with a new wording "Secondary Unit of Purchase"
