### PR TITLE
[IMP] mrp_production_project_estimated_cost: modificadas las funciones para obtener los valores por defecto de las ubicaciones de la OF

### DIFF
--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -70,6 +70,22 @@ class MrpProduction(models.Model):
                                         "mrp_production_id",
                                         string="Cost Lines")
 
+    @api.multi
+    def _src_id_default(self):
+        location_id = super(MrpProduction, self)._src_id_default()
+        if not location_id:
+            x = self.env['ir.values'].get_defaults_dict('mrp.production')
+            location_id = x.get('location_src_id', False)
+        return location_id
+
+    @api.multi
+    def _dest_id_default(self):
+        location_id = super(MrpProduction, self)._dest_id_default()
+        if not location_id:
+            x = self.env['ir.values'].get_defaults_dict('mrp.production')
+            location_id = x.get('location_dest_id', False)
+        return location_id
+
     @api.model
     def create(self, values):
         sequence_obj = self.pool['ir.sequence']

--- a/mrp_production_project_estimated_cost/models/mrp_production.py
+++ b/mrp_production_project_estimated_cost/models/mrp_production.py
@@ -70,22 +70,6 @@ class MrpProduction(models.Model):
                                         "mrp_production_id",
                                         string="Cost Lines")
 
-    @api.multi
-    def _src_id_default(self):
-        location_id = super(MrpProduction, self)._src_id_default()
-        if not location_id:
-            x = self.env['ir.values'].get_defaults_dict('mrp.production')
-            location_id = x.get('location_src_id', False)
-        return location_id
-
-    @api.multi
-    def _dest_id_default(self):
-        location_id = super(MrpProduction, self)._dest_id_default()
-        if not location_id:
-            x = self.env['ir.values'].get_defaults_dict('mrp.production')
-            location_id = x.get('location_dest_id', False)
-        return location_id
-
     @api.model
     def create(self, values):
         sequence_obj = self.pool['ir.sequence']

--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
@@ -32,8 +32,6 @@ class WizCreateFictitiousOf(models.TransientModel):
                     'product_qty': 1,
                     'date_planned': self.date_planned,
                     'user_id': self._uid,
-                    'location_src_id': production_obj._src_id_default(),
-                    'location_dest_id': production_obj._dest_id_default(),
                     'active': False,
                     'product_uom': product.uom_id.id,
                     'project_id': self.project_id.id


### PR DESCRIPTION
Al crear una OF ficticia, se utilizaban las funciones _src_id_default y _dest_id_default para obtener los valores de las ubicaciones, pero estas funciones unicamente devuelven aquellas ubicaciones que ha creado el usuario, si el usuario activo no ha creado ninguna ubicación, no carga ese dato y da un error de integridad al ser estos campos requeridos. He ampliado las funciones para que coja el valor por defecto asignado en el caso de que exista uno.
