### PR TITLE
[IMP] sale_documents_comments: añadir comentario del parent cuando exista + pasar codigo a la nueva api

### DIFF
--- a/sale_documents_comments/README.rst
+++ b/sale_documents_comments/README.rst
@@ -1,0 +1,16 @@
+Comments for sale documents (order, picking and invoice)
+========================================================
+With this module you can add specific comments to a customer, for sale order,
+delivery order and invoices. Part of the info will be passed from one to other.
+Those data will be automatically added to each item.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/sale_documents_comments/__openerp__.py
+++ b/sale_documents_comments/__openerp__.py
@@ -30,17 +30,8 @@
     "author": "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
-    "contributors": [
-        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
-    ],
     "category": "Custom Module",
     "website": "http://www.odoomrp.com",
-    "summary": "",
-    "description": """
-With this module you can add specific comments to a customer, for sale order,
-delivery order and invoices. Part of the info will be passed from one to other.
-Those data will be automatically added to each item.
-    """,
     "data": [
         "views/partner_view.xml",
         "views/sale_view.xml",

--- a/sale_documents_comments/models/account.py
+++ b/sale_documents_comments/models/account.py
@@ -35,7 +35,7 @@ class AccountInvoice(models.Model):
         if partner_id:
             partner_obj = self.env['res.partner']
             partner = partner_obj.browse(partner_id)
-            comment = partner.invoice_comment
+            comment = partner.invoice_comment or ''
             if partner.parent_id:
                 comment += '\n' + (partner.parent_id.invoice_comment or '')
             val['value']['sale_comment'] = comment

--- a/sale_documents_comments/models/account.py
+++ b/sale_documents_comments/models/account.py
@@ -16,26 +16,27 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp import models, fields, api
 
 
-class AccountInvoice(orm.Model):
+class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
-    _columns = {
-        'sale_comment': fields.text('Internal comments'),
-    }
+    sale_comment = fields.Text(string='Internal comments')
 
-    def onchange_partner_id(self, cr, uid, ids, invoice_type, partner_id,
+    @api.multi
+    def onchange_partner_id(self, invoice_type, partner_id,
                             date_invoice=False, payment_term=False,
-                            partner_bank_id=False, company_id=False,
-                            context=None):
+                            partner_bank_id=False, company_id=False):
         val = super(AccountInvoice, self).onchange_partner_id(
-            cr, uid, ids, invoice_type, partner_id, date_invoice=date_invoice,
+            invoice_type, partner_id, date_invoice=date_invoice,
             payment_term=payment_term, partner_bank_id=partner_bank_id,
-            company_id=company_id, context=context)
+            company_id=company_id)
         if partner_id:
-            partner_obj = self.pool['res.partner']
-            partner = partner_obj.browse(cr, uid, partner_id, context=context)
-            val['value']['sale_comment'] = partner.invoice_comment
+            partner_obj = self.env['res.partner']
+            partner = partner_obj.browse(partner_id)
+            comment = partner.invoice_comment
+            if partner.parent_id:
+                comment += '\n' + (partner.parent_id.invoice_comment or '')
+            val['value']['sale_comment'] = comment
         return val

--- a/sale_documents_comments/models/partner.py
+++ b/sale_documents_comments/models/partner.py
@@ -16,18 +16,16 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp import models, fields
 
 
-class ResPartner(orm.Model):
+class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    _columns = {
-        'sale_comment': fields.text('Comments for sale orders'),
-        'sale_propagated_comment': fields.text('Propagated comments for sale'
-                                               ' orders'),
-        'picking_comment': fields.text('Comments for pickings'),
-        'picking_propagated_comment': fields.text('Propagated comments for'
-                                                  ' pickings'),
-        'invoice_comment': fields.text('Comments for invoices'),
-    }
+    sale_comment = fields.Text(string='Comments for sale orders')
+    sale_propagated_comment = fields.Text(string='Propagated comments for sale'
+                                          ' orders')
+    picking_comment = fields.Text(string='Comments for pickings')
+    picking_propagated_comment = fields.Text(string='Propagated comments for'
+                                            ' pickings')
+    invoice_comment = fields.Text(string='Comments for invoices')

--- a/sale_documents_comments/models/partner.py
+++ b/sale_documents_comments/models/partner.py
@@ -27,5 +27,5 @@ class ResPartner(models.Model):
                                           ' orders')
     picking_comment = fields.Text(string='Comments for pickings')
     picking_propagated_comment = fields.Text(string='Propagated comments for'
-                                            ' pickings')
+                                             ' pickings')
     invoice_comment = fields.Text(string='Comments for invoices')

--- a/sale_documents_comments/models/sale.py
+++ b/sale_documents_comments/models/sale.py
@@ -16,34 +16,36 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp import models, fields, api
 
 
-class SaleOrder(orm.Model):
+class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    _columns = {
-        'comment': fields.text('Internal comments'),
-        'propagated_comment': fields.text('Propagated internal comments'),
-    }
+    comment = fields.Text(string='Internal comments')
+    propagated_comment = fields.Text(string='Propagated internal comments')
 
-    def _prepare_invoice(self, cr, uid, order, lines, context=None):
-        res = super(SaleOrder, self)._prepare_invoice(cr, uid, order, lines,
-                                                      context=context)
+    @api.model
+    def _prepare_invoice(self, order, lines):
+        res = super(SaleOrder, self)._prepare_invoice(order, lines)
         if 'sale_comment' not in res:
             res['sale_comment'] = order.propagated_comment
         else:
-            res['sale_comment'] += ' ' + order.propagated_comment
+            res['sale_comment'] += ' ' + (order.propagated_comment or '')
         return res
 
-    def onchange_partner_id(self, cr, uid, ids, partner_id, context=None):
-        val = super(SaleOrder, self).onchange_partner_id(cr, uid, ids,
-                                                         partner_id,
-                                                         context=context)
+    @api.multi
+    def onchange_partner_id(self, partner_id):
+        val = super(SaleOrder, self).onchange_partner_id(partner_id)
         if partner_id:
-            partner_obj = self.pool['res.partner']
-            partner = partner_obj.browse(cr, uid, partner_id, context=context)
-            val['value'].update(
-                {'comment': partner.sale_comment,
-                 'propagated_comment': partner.sale_propagated_comment})
+            partner_obj = self.env['res.partner']
+            partner = partner_obj.browse(partner_id)
+            comment = partner.sale_comment
+            p_comment = partner.sale_propagated_comment
+            if partner.parent_id:
+                comment += '\n' + (partner.parent_id.sale_comment or '')
+                p_comment += '\n' + (partner.parent_id.sale_propagated_comment
+                                     or '')
+            val['value'].update({'comment': comment,
+                                 'propagated_comment': p_comment})
         return val

--- a/sale_documents_comments/models/sale.py
+++ b/sale_documents_comments/models/sale.py
@@ -40,8 +40,8 @@ class SaleOrder(models.Model):
         if partner_id:
             partner_obj = self.env['res.partner']
             partner = partner_obj.browse(partner_id)
-            comment = partner.sale_comment
-            p_comment = partner.sale_propagated_comment
+            comment = partner.sale_comment or ''
+            p_comment = partner.sale_propagated_comment or ''
             if partner.parent_id:
                 comment += '\n' + (partner.parent_id.sale_comment or '')
                 p_comment += '\n' + (partner.parent_id.sale_propagated_comment

--- a/sale_documents_comments/models/stock.py
+++ b/sale_documents_comments/models/stock.py
@@ -32,8 +32,8 @@ class StockPicking(models.Model):
         picking_com = ''
         picking_pcom = ''
         if self.partner_id:
-            picking_com = self.partner_id.picking_comment
-            picking_pcom = self.partner_id.picking_propagated_comment
+            picking_com = self.partner_id.picking_comment or ''
+            picking_pcom = self.partner_id.picking_propagated_comment or ''
             parent = self.partner_id.parent_id
             if parent:
                 picking_com += '\n' + (parent.picking_comment or '')
@@ -60,8 +60,8 @@ class StockPicking(models.Model):
                         values['sale_propagated_comment'] += (
                             sale.propagated_comment)
             partner = partner_obj.browse(partner_id)
-            picking_com = partner.picking_comment
-            picking_pcom = partner.picking_propagated_comment
+            picking_com = partner.picking_comment or ''
+            picking_pcom = partner.picking_propagated_comment or ''
             if partner.parent_id:
                 picking_com += '\n' + partner.parent_id.picking_comment
                 picking_pcom += ('\n' +

--- a/sale_documents_comments/models/stock.py
+++ b/sale_documents_comments/models/stock.py
@@ -16,63 +16,68 @@
 #
 ##############################################################################
 
-from openerp.osv import orm, fields
+from openerp import api, models, fields
 
 
-class StockPicking(orm.Model):
+class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    _columns = {
-        'sale_comment': fields.text('Internal comments'),
-        'sale_propagated_comment': fields.text('Propagated internal comments'),
-    }
+    sale_comment = fields.Text(string='Internal comments')
+    sale_propagated_comment = fields.Text(string='Propagated internal'
+                                          ' comments')
 
-    def onchange_partner_id(self, cr, uid, ids, partner_id, context=None):
-        if not partner_id:
-            return {}
-        partner_obj = self.pool['res.partner']
-        partner = partner_obj.browse(cr, uid, partner_id, context=context)
-        value = {
-            'sale_comment': partner.picking_comment,
-            'sale_propagated_comment': partner.picking_propagated_comment,
-        }
-        return {'value': value}
+    @api.one
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        picking_com = ''
+        picking_pcom = ''
+        if self.partner_id:
+            picking_com = self.partner_id.picking_comment
+            picking_pcom = self.partner_id.picking_propagated_comment
+            parent = self.partner_id.parent_id
+            if parent:
+                picking_com += '\n' + (parent.picking_comment or '')
+                picking_pcom += '\n' + (parent.picking_propagated_comment or
+                                        '')
+        self.sale_comment = picking_com
+        self.sale_propagated_comment = picking_pcom
 
-    def create(self, cr, uid, values, context=None):
+    @api.model
+    def create(self, values):
         partner_id = values.get('partner_id', False)
         origin = values.get('origin', False)
         if partner_id:
-            partner_obj = self.pool['res.partner']
+            partner_obj = self.env['res.partner']
             if 'sale_comment' not in values:
                 values['sale_comment'] = ''
             if 'sale_propagated_comment' not in values:
                 values['sale_propagated_comment'] = ''
             if origin:
-                sale_obj = self.pool['sale.order']
-                sale_ids = sale_obj.search(cr, uid, [('name', '=', origin)],
-                                           context=context)
-                if sale_ids:
-                    sale = sale_obj.browse(cr, uid, sale_ids[0],
-                                           context=context)
+                sale_obj = self.env['sale.order']
+                sale = sale_obj.search([('name', '=', origin)], limit=1)
+                if sale:
                     if sale.propagated_comment:
                         values['sale_propagated_comment'] += (
                             sale.propagated_comment)
-            partner = partner_obj.browse(cr, uid, partner_id, context=context)
-            if (partner.picking_comment and
-                    values['sale_comment'] != partner.picking_comment):
-                values['sale_comment'] = (partner.picking_comment + '\n' +
-                                          values['sale_comment'])
-            if (partner.picking_propagated_comment and
-                    (values['sale_propagated_comment'] !=
-                     partner.picking_propagated_comment)):
+            partner = partner_obj.browse(partner_id)
+            picking_com = partner.picking_comment
+            picking_pcom = partner.picking_propagated_comment
+            if partner.parent_id:
+                picking_com += '\n' + partner.parent_id.picking_comment
+                picking_pcom += ('\n' +
+                                 partner.parent_id.picking_propagated_comment)
+            if (picking_com and values['sale_comment'] != picking_com):
+                values['sale_comment'] = (picking_com + '\n' +
+                                          (values['sale_comment'] or ''))
+            if (picking_pcom and
+                    (values['sale_propagated_comment'] != picking_pcom)):
                 values['sale_propagated_comment'] = (
-                    partner.picking_propagated_comment + '\n' +
-                    values['sale_propagated_comment'])
-        return super(StockPicking, self).create(cr, uid, values,
-                                                context=context)
+                    picking_pcom + '\n' + (values['sale_propagated_comment'] or
+                                           ''))
+        return super(StockPicking, self).create(values)
 
-    def _create_invoice_from_picking(self, cr, uid, picking, values,
-                                     context=None):
+    @api.model
+    def _create_invoice_from_picking(self, picking, values):
         values['sale_comment'] = picking.sale_propagated_comment
-        return super(StockPicking, self)._create_invoice_from_picking(
-            cr, uid, picking, values, context=context)
+        return super(StockPicking, self)._create_invoice_from_picking(picking,
+                                                                      values)

--- a/sale_documents_comments/views/stock_view.xml
+++ b/sale_documents_comments/views/stock_view.xml
@@ -6,10 +6,6 @@
             <field name="model">stock.picking</field>
             <field name="inherit_id" ref="stock.view_picking_form" />
             <field name="arch" type="xml">
-                <field name="partner_id" position="attributes">
-                    <attribute name="on_change">onchange_partner_id(partner_id,
-                        context)</attribute>
-                </field>
                 <notebook position="inside">
                     <page string="Customer observations">
                         <group colspan="2" col="2">


### PR DESCRIPTION
https://github.com/odoomrp/odoomrp-almetac/issues/284#event-275987880

No incluye los comentarios del cliente padre cuando el cliente seleccionado es una dirección.
Por solicitud de @anajuaristi además de cargar los comentarios del padre, se concatenan con las del hijo.
Aprovechando que estaba tocando el módulo, lo he pasado a la nueva api.
