### PR TITLE
[FIX] sale_documents_comments: asegurar de que no se va a pasar un False al concatenar strings

### DIFF
--- a/sale_documents_comments/models/stock.py
+++ b/sale_documents_comments/models/stock.py
@@ -63,9 +63,10 @@ class StockPicking(models.Model):
             picking_com = partner.picking_comment or ''
             picking_pcom = partner.picking_propagated_comment or ''
             if partner.parent_id:
-                picking_com += '\n' + partner.parent_id.picking_comment
+                picking_com += '\n' + (partner.parent_id.picking_comment or '')
                 picking_pcom += ('\n' +
-                                 partner.parent_id.picking_propagated_comment)
+                                 (partner.parent_id.picking_propagated_comment
+                                  or ''))
             if (picking_com and values['sale_comment'] != picking_com):
                 values['sale_comment'] = (picking_com + '\n' +
                                           (values['sale_comment'] or ''))


### PR DESCRIPTION
Se ha detectado un bug: cuando se crea una factura desde un albarán que no tiene comentarios, salta un traceback al concatenar los comentarios.
