### PR TITLE
[FIX] stock_picking_wave_package_info: fix bug in function "do_save_for_...

### DIFF
--- a/stock_picking_wave_package_info/models/stock.py
+++ b/stock_picking_wave_package_info/models/stock.py
@@ -31,12 +31,15 @@ class StockPickingWave(models.Model):
         if self.packages_info:
             self.packages_info.unlink()
         if self.packages:
+            sequence = 0
             for package in self.packages:
                 kg_net = sum(x.product_qty for x in
                              self.pickings_operations.filtered(
                                  lambda r: r.result_package_id.id ==
                                  package.id))
+                sequence += 1
                 vals = {'wave': self.id,
+                        'sequence': sequence,
                         'package': package.id,
                         'kg_net': kg_net,
                         'gross_net': kg_net + package.empty_weight

--- a/stock_picking_wave_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_package_info/wizard/stock_transfer_details.py
@@ -42,13 +42,11 @@ class StockTransferDetails(models.TransientModel):
                         'owner_id': prod.owner_id.id,
                     }
                     if prod.packop_id:
-                        if prod.packop_id.product_qty != prod.quantity:
-                            qty = prod.packop_id.product_qty - prod.quantity
-                            prod.packop_id.write({'product_qty': qty})
-                            pack_datas['picking_id'] = picking.id
-                            operation_obj.create(pack_datas)
-                        else:
-                            prod.packop_id.write(pack_datas)
+                        prod.packop_id.with_context(no_recompute=True).write(
+                            pack_datas)
+                    else:
+                        pack_datas['picking_id'] = picking.id
+                        operation_obj.create(pack_datas)
         if 'origin_wave' in self._context:
             origin_wave = wave_obj.browse(self._context['origin_wave'])
             origin_wave._catch_operations()


### PR DESCRIPTION
...later".

A la mañana se me había olvidado subir este módulo para arreglar el BUG que había en la función "do_save_for_later". 
He aprovechado esta subida para ir sumando 1 a la secuencia del objeto "Total Kg. and Lots by package", cuando grabamos este objeto desde wave, y no desde picking.
