### PR TITLE
[IMP] stock_picking_package_info: Clear information packets when picking...

### DIFF
--- a/stock_picking_package_info/models/stock.py
+++ b/stock_picking_package_info/models/stock.py
@@ -27,6 +27,21 @@ class StockPicking(models.Model):
     num_packages = fields.Integer(
         string='Num. Packages', compute='_compute_num_packages', store=True)
 
+    @api.multi
+    def action_assign(self):
+        super(StockPicking, self).action_assign()
+        for picking in self:
+            picking._delete_packages_information()
+        return True
+
+    @api.one
+    def _delete_packages_information(self):
+        self.pack_operation_ids.unlink()
+        self.packages.unlink()
+        self.packages_info.unlink()
+        self.package_totals.unlink()
+        return True
+
     def _catch_operations(self):
         self.packages = [
             operation.result_package_id.id for operation in

--- a/stock_picking_package_info/models/stock.py
+++ b/stock_picking_package_info/models/stock.py
@@ -30,8 +30,7 @@ class StockPicking(models.Model):
     @api.multi
     def action_assign(self):
         super(StockPicking, self).action_assign()
-        for picking in self:
-            picking._delete_packages_information()
+        self._delete_packages_information()
         return True
 
     @api.one

--- a/stock_picking_package_info/views/stock_picking_view.xml
+++ b/stock_picking_package_info/views/stock_picking_view.xml
@@ -36,21 +36,19 @@
                                 </tree>
                             </field>
                         </group>
+                        <group name="group_packages_info" string="Total Kg. and Lots by package">
+                            <field name="packages_info" nolabel="1">
+                                <tree>
+                                    <field name="package" />
+                                    <field name="kg_net" sum="sum_kg_net"/>
+                                    <field name="lots" />
+                                    <field name="gross_net" sum="sum_gross_net"/>
+                                </tree>
+                            </field>
+                        </group>
                         <field name="num_packages" invisible="1"/>
                     </page>
                 </page>
-                <field name="pack_operation_ids" position="after">
-                    <group name="group_packages_info" string="Total Kg. and Lots by package">
-                        <field name="packages_info" nolabel="1">
-                            <tree>
-                                <field name="package" />
-                                <field name="kg_net" sum="sum_kg_net"/>
-                                <field name="lots" />
-                                <field name="gross_net" sum="sum_gross_net"/>
-                            </tree>
-                        </field>
-                    </group>
-                </field>
             </field>
         </record>
     </data>

--- a/stock_picking_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_package_info/wizard/stock_transfer_details.py
@@ -19,11 +19,10 @@ class StockTransferDetails(models.TransientModel):
     def do_save_for_later(self):
         operation_obj = self.env['stock.pack.operation'].with_context(
             no_recompute=True)
-        # Create new and update existing pack operations
-
         if not self.item_ids and not self.packop_ids:
             self.picking_id._delete_packages_information()
             return True
+        # Create new and update existing pack operations
         for lstits in [self.item_ids, self.packop_ids]:
             for prod in lstits:
                 pack_datas = {

--- a/stock_picking_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_package_info/wizard/stock_transfer_details.py
@@ -20,6 +20,10 @@ class StockTransferDetails(models.TransientModel):
         operation_obj = self.env['stock.pack.operation'].with_context(
             no_recompute=True)
         # Create new and update existing pack operations
+
+        if not self.item_ids and not self.packop_ids:
+            self.picking_id._delete_packages_information()
+            return True
         for lstits in [self.item_ids, self.packop_ids]:
             for prod in lstits:
                 pack_datas = {

--- a/stock_picking_wave_management/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_management/wizard/stock_transfer_details.py
@@ -126,6 +126,7 @@ class StockTransferDetails(models.TransientModel):
 
 class StockTransferDetailsItems(models.TransientModel):
     _inherit = 'stock.transfer_details_items'
+    _order = 'destinationloc_id'
 
     picking_id = fields.Many2one(
         'stock.picking', string="Picking", required=True)

--- a/stock_picking_wave_management/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_management/wizard/stock_transfer_details.py
@@ -126,7 +126,6 @@ class StockTransferDetails(models.TransientModel):
 
 class StockTransferDetailsItems(models.TransientModel):
     _inherit = 'stock.transfer_details_items'
-    _order = 'destinationloc_id'
 
     picking_id = fields.Many2one(
         'stock.picking', string="Picking", required=True)

--- a/stock_picking_wave_package_info/models/stock.py
+++ b/stock_picking_wave_package_info/models/stock.py
@@ -2,7 +2,19 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from openerp import models, fields
+from openerp import models, fields, api
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def action_assign(self):
+        super(StockPicking, self).action_assing()
+        for picking in self:
+            if picking.wave_id:
+                picking.wave_id._delete_packages_information()
+        return True
 
 
 class StockPickingWave(models.Model):
@@ -19,6 +31,14 @@ class StockPickingWave(models.Model):
         "stock.picking.package.total", "wave",
         string="Total UL Packages Info", readonly=True)
     num_packages = fields.Integer(string='# Packages', readonly=True)
+
+    @api.one
+    def _delete_packages_information(self):
+        self.pickings_operations.unlink()
+        self.packages.unlink()
+        self.packages_info.unlink()
+        self.package_totals.unlink()
+        return True
 
     def _catch_operations(self):
         self.packages = [

--- a/stock_picking_wave_package_info/views/stock_picking_wave_view.xml
+++ b/stock_picking_wave_package_info/views/stock_picking_wave_view.xml
@@ -31,21 +31,19 @@
                                 </tree>
                             </field>
                         </group>
+                        <group name="group_packages_info" string="Total Kg. and Lots by package">
+                            <field name="packages_info" nolabel="1">
+                                <tree>
+                                    <field name="package" />
+                                    <field name="kg_net" sum="sum_kg_net"/>
+                                    <field name="lots" />
+                                    <field name="gross_net" sum="sum_gross_net"/>
+                                </tree>
+                            </field>
+                        </group>
                         <field name="num_packages" invisible="1"/>
                     </page>
                 </page>
-                <field name="pickings_operations" position="after">
-                    <group name="group_packages_info" string="Total Kg. and Lots by package">
-                        <field name="packages_info" nolabel="1">
-                            <tree>
-                                <field name="package" />
-                                <field name="kg_net" sum="sum_kg_net"/>
-                                <field name="lots" />
-                                <field name="gross_net" sum="sum_gross_net"/>
-                            </tree>
-                        </field>
-                    </group>
-                </field>
             </field>
         </record>
     </data>

--- a/stock_picking_wave_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_package_info/wizard/stock_transfer_details.py
@@ -22,6 +22,13 @@ class StockTransferDetails(models.TransientModel):
     def do_save_for_later(self):
         wave_obj = self.env['stock.picking.wave']
         operation_obj = self.env['stock.pack.operation']
+        if not self.item_ids and not self.packop_ids:
+            for picking in self.picking_ids:
+                picking._delete_packages_information()
+            if 'origin_wave' in self._context:
+                origin_wave = wave_obj.browse(self._context['origin_wave'])
+                origin_wave._delete_packages_information()
+            return True
         for picking in self.picking_ids:
             # Create new and update existing pack operations
             for line in [self.item_ids.filtered(lambda x: x.picking_id.id ==


### PR DESCRIPTION
...s are checked availability, and when all lines are deleted wizard. Show "Total packets per kg lot" to the tab "Packages".

[IMP] stock_picking_wave_package_info: Clear information packets when pickings are checked availability, and when all lines are deleted wizard. Show "Total packets per kg lot" to the tab "Packages".
[IMP] stock_picking_wave_management: Order wizard lines by destinationloc_id

Se han modificado 3 modulos, son estos:

1.- stock_picking_package_info y stock_picking_wave_package_info: Borrar informacion de paquetes cuando se comprueba disponibilidad en albaranes, y cuando se borran todas las líneas del wizard de transferir. Mostrar "Total paquetes por kg lot" a la pestaña de "Paquetes".

2.- stock_picking_wave_management: Mostrar líneas del wizard de transferir de albaranes, ordenados por paquete de salida.
