### PR TITLE
[FIX] stock_picking_wave_management: Confirm only pickings that are in d...

### DIFF
--- a/stock_picking_wave_management/models/stock_picking_wave.py
+++ b/stock_picking_wave_management/models/stock_picking_wave.py
@@ -28,6 +28,16 @@ class StockPickingWave(models.Model):
         compute="_count_assigned_pickings", string="Assigned pickings")
     partner = fields.Many2one('res.partner', 'Partner')
 
+    @api.multi
+    def confirm_picking(self):
+        picking_obj = self.env['stock.picking']
+        for wave in self:
+            pickings = picking_obj.search([('wave_id', '=', wave.id),
+                                           ('state', '=', 'draft')])
+            pickings.action_assign()
+            wave.state = 'in_progress'
+        return True
+
     @api.one
     def button_check_availability(self):
         pickings = self.picking_ids.filtered(lambda x: x.state == 'confirmed')

--- a/stock_picking_wave_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_package_info/wizard/stock_transfer_details.py
@@ -15,6 +15,7 @@ class StockTransferDetails(models.TransientModel):
         result = super(StockTransferDetails, self).do_detailed_transfer()
         if 'origin_wave' in self._context:
             origin_wave = wave_obj.browse(self._context['origin_wave'])
+            origin_wave.state = 'done'
             origin_wave._catch_operations()
             for picking in origin_wave.picking_ids:
                 picking._catch_operations()


### PR DESCRIPTION
...raft status.

[IMP] stock_picking_wave_package_info: Put picking wave in state "done" when transfer pickings.

En "stock_picking_wave_management", al pulsar el botón confirmar, confirmar solo aquellos albaranes que estén en estado borrador.

En "stock_picking_wave_package_info", cuando se realiza la transferencia de todos los albaranes de la agrupación, poner la agrupación como realizada.
