### PR TITLE
[IMP] improved strings in mrp_lock_lot + FR translation

### DIFF
--- a/mrp_lock_lot/README.rst
+++ b/mrp_lock_lot/README.rst
@@ -1,16 +1,18 @@
-MRP lock lot
-============
-* This module allows you to define whether a lot is locked or not. By default,
-  the value that will catch, which will define in product category, in the
-  field "Create in locked status when create a lot".
-* To lock/unlock a lot, have created 2 new buttons in form. Also from the tree
-  view, by selecting the lots in option "Lock/Unlock lots".
-* When you lock one lot, validates that does not exist a quant assigned to the
-  lot, or if exist the quant assigned to the lot, that there is no movement of
-  stock, with different state to "done", and with destination location type
-  virtual/company.
-* Changes in manufacturing, and delivery orders, to selecting the locked
-  bundles is prevented.
+Block down Serial Numbers/lots
+==============================
+This module allows you to define whether a Serial Number/lot is blocked
+or not.
+The default value can be set on the Product Category, in the
+field "Block new Serial Numbers/lots".
+
+Two new buttons let you block/unblock a Serial Number/lot in the form view.
+Blocking/unblocking can also be done from the list view, by selecting the
+Serial Numbers/lots and choosing the option "Block/Unblock lots".
+
+Only lots which have no reservation can be blocked.
+
+Manufacturing Orders and Delivery Orders are not allowed to select a
+blocked down Serial Number/lot.
 
 Credits
 =======

--- a/mrp_lock_lot/data/mrp_lock_lot_data.xml
+++ b/mrp_lock_lot/data/mrp_lock_lot_data.xml
@@ -3,16 +3,16 @@
     <data>
         <!-- Lot-related subtypes for messaging / Chatter -->
         <record id="mt_lock_lot" model="mail.message.subtype">
-            <field name="name">Lot Locked</field>
+            <field name="name">Serial Number/lot blocked</field>
             <field name="res_model">stock.production.lot</field>
             <field name="default" eval="False"/>
-            <field name="description">Lot Locked</field>
+            <field name="description">Serial Number/lot blocked</field>
         </record>
         <record id="mt_unlock_lot" model="mail.message.subtype">
-            <field name="name">Lot Unlocked</field>
+            <field name="name">Serial Number/lot unblocked</field>
             <field name="res_model">stock.production.lot</field>
             <field name="default" eval="False"/>
-            <field name="description">Lot Unlocked</field>
+            <field name="description">Serial Number/lot unblocked</field>
         </record>
     </data>
 </openerp>

--- a/mrp_lock_lot/i18n/es.po
+++ b/mrp_lock_lot/i18n/es.po
@@ -22,7 +22,7 @@ msgstr "Cancelar"
 
 #. module: mrp_lock_lot
 #: field:product.category,lot_default_locked:0
-msgid "Create lot in locked status"
+msgid "Block new Serial Numbers/lots"
 msgstr "Crear lote en estado bloqueado"
 
 #. module: mrp_lock_lot
@@ -38,7 +38,7 @@ msgstr "Creado el"
 #. module: mrp_lock_lot
 #: code:addons/mrp_lock_lot/models/mrp_production_lot.py:43
 #, python-format
-msgid "Error!: Found stock movements for lot: \"%\" with location destination type in virtual/company"
+msgid "Error! Serial Number/Lot \"%s\" currently has reservations."
 msgstr "Error!: Encontrados movimientos de stock para el lote: \"%\" con ubicación destino tipo virtual/empresa"
 
 #. module: mrp_lock_lot
@@ -48,7 +48,7 @@ msgstr "ID"
 
 #. module: mrp_lock_lot
 #: help:product.category,lot_default_locked:0
-msgid "If checked, production lots will be created locked by default"
+msgid "If checked, future Serial Numbers/lots will be created blocked by default"
 msgstr "Si marcado, los lotes de producción se crearán bloqueados por defecto"
 
 #. module: mrp_lock_lot
@@ -63,27 +63,27 @@ msgstr "Última actualización el"
 
 #. module: mrp_lock_lot
 #: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
-msgid "Lock"
+msgid "Block"
 msgstr "Bloquear"
 
 #. module: mrp_lock_lot
 #: view:product.category:mrp_lock_lot.product_category_form_view_inh_locklot
-msgid "Lock Lot Properties"
+msgid "Serial Nunber/lot blocking"
 msgstr "Propiedades de bloqueo de lotes"
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Lock lots"
+msgid "Block Serial Numbers/Lots"
 msgstr "Bloquear lotes"
 
 #. module: mrp_lock_lot
 #: model:ir.actions.act_window,name:mrp_lock_lot.action_lock_lot
-msgid "Lock/Unlock lot"
+msgid "Block/Unblock Serial Number/lot"
 msgstr "Bloquear/Desbloquear lote"
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Lock/Unlock lots"
+msgid "Block/Unblock Serial Numbers/lots"
 msgstr "Bloquear/Desbloquear lotes"
 
 #. module: mrp_lock_lot
@@ -91,7 +91,7 @@ msgstr "Bloquear/Desbloquear lotes"
 #: field:stock.production.lot,locked:0
 #: view:stock.quant:mrp_lock_lot.quant_search_view_inh_locklot
 #: field:stock.quant,locked:0
-msgid "Locked"
+msgid "Blocked"
 msgstr "Bloqueado"
 
 #. module: mrp_lock_lot
@@ -102,13 +102,13 @@ msgstr "Lote"
 #. module: mrp_lock_lot
 #: model:mail.message.subtype,description:mrp_lock_lot.mt_lock_lot
 #: model:mail.message.subtype,name:mrp_lock_lot.mt_lock_lot
-msgid "Lot Locked"
+msgid "Serial Number/lot blocked"
 msgstr "Lote bloqueado"
 
 #. module: mrp_lock_lot
 #: model:mail.message.subtype,description:mrp_lock_lot.mt_unlock_lot
 #: model:mail.message.subtype,name:mrp_lock_lot.mt_unlock_lot
-msgid "Lot Unlocked"
+msgid "Serial Number/lot unblocked"
 msgstr "Lote desbloqueado"
 
 #. module: mrp_lock_lot
@@ -133,17 +133,17 @@ msgstr "Quants"
 
 #. module: mrp_lock_lot
 #: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
-msgid "Unlock"
+msgid "Unblock"
 msgstr "Desbloquear"
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Unlock lots"
+msgid "Unblock Serial Numbers/Lots"
 msgstr "Desbloquear lotes"
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "What do you want to do with selected lots?"
+msgid "What do you want to do with selected Serial Numbers/Lots?"
 msgstr "¿Que quieres hacer con los lotes seleccionados?"
 
 #. module: mrp_lock_lot

--- a/mrp_lock_lot/i18n/fr.po
+++ b/mrp_lock_lot/i18n/fr.po
@@ -1,0 +1,153 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_lock_lot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-30 09:55+0000\n"
+"PO-Revision-Date: 2015-03-30 09:55+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "Cancel"
+msgstr "Annuler"
+
+#: field:product.category,lot_default_locked:0
+#. module: mrp_lock_lot
+msgid "Block new Serial Numbers/lots"
+msgstr "Bloquer les lots créés"
+
+#: field:wiz.lock.lot,create_uid:0
+#. module: mrp_lock_lot
+msgid "Created by"
+msgstr "Créé par"
+
+#: field:wiz.lock.lot,create_date:0
+#. module: mrp_lock_lot
+msgid "Created on"
+msgstr "Créé le"
+
+#: code:addons/mrp_lock_lot/models/mrp_production_lot.py:43
+#. module: mrp_lock_lot
+#, python-format
+msgid "Error! Serial Number/Lot \"%s\" currently has reservations."
+msgstr "Erreur ! Il existe actuellement des reservations pour le numéro de série/lot \"%s\"."
+
+#: field:wiz.lock.lot,id:0
+#. module: mrp_lock_lot
+msgid "ID"
+msgstr "Id."
+
+#: help:product.category,lot_default_locked:0
+#. module: mrp_lock_lot
+msgid "If checked, future Serial Numbers/lots will be created blocked by default"
+msgstr "Si coché, les lots de production seront créés verrouillés par défaut"
+
+#: field:wiz.lock.lot,write_uid:0
+#. module: mrp_lock_lot
+msgid "Last Updated by"
+msgstr "Mis à jour par"
+
+#: field:wiz.lock.lot,write_date:0
+#. module: mrp_lock_lot
+msgid "Last Updated on"
+msgstr "Mis à jour le"
+
+#: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
+#. module: mrp_lock_lot
+msgid "Block"
+msgstr "Bloquer"
+
+#: view:product.category:mrp_lock_lot.product_category_form_view_inh_locklot
+#. module: mrp_lock_lot
+msgid "Serial Nunber/lot blocking"
+msgstr "Blocage des numéros de série/lots"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "Block Serial Numbers/Lots"
+msgstr "Bloquer les numéros de série/lots"
+
+#: model:ir.actions.act_window,name:mrp_lock_lot.action_lock_lot
+#. module: mrp_lock_lot
+msgid "Block/Unblock Serial Number/lot"
+msgstr "Bloquer/débloquer le n° de série/lot"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "Block/Unblock Serial Numbers/lots"
+msgstr "Bloquer/débloquer les numéro de série/lots"
+
+#: view:stock.production.lot:mrp_lock_lot.search_product_lot_filter_inh_locklot
+#: field:stock.production.lot,locked:0
+#: view:stock.quant:mrp_lock_lot.quant_search_view_inh_locklot
+#: field:stock.quant,locked:0
+#. module: mrp_lock_lot
+msgid "Blocked"
+msgstr "Bloqué"
+
+#: view:stock.quant:mrp_lock_lot.quant_search_view_inh_locklot
+#. module: mrp_lock_lot
+msgid "Lot"
+msgstr "Lot"
+
+#: model:mail.message.subtype,description:mrp_lock_lot.mt_lock_lot
+#: model:mail.message.subtype,name:mrp_lock_lot.mt_lock_lot
+#. module: mrp_lock_lot
+msgid "Serial Number/lot blocked"
+msgstr "Numéro de série/lot bloqué"
+
+#: model:mail.message.subtype,description:mrp_lock_lot.mt_unlock_lot
+#: model:mail.message.subtype,name:mrp_lock_lot.mt_unlock_lot
+#. module: mrp_lock_lot
+msgid "Serial Number/lot unblocked"
+msgstr "Numéro de série/lot débloqué"
+
+#: model:ir.model,name:mrp_lock_lot.model_stock_production_lot
+#. module: mrp_lock_lot
+msgid "Lot/Serial"
+msgstr "Lot/n° de série"
+
+#: view:stock.production.lot:mrp_lock_lot.search_product_lot_filter_inh_locklot
+#. module: mrp_lock_lot
+msgid "Product"
+msgstr "Article"
+
+#: model:ir.model,name:mrp_lock_lot.model_product_category
+#. module: mrp_lock_lot
+msgid "Product Category"
+msgstr "Catégorie d'articles"
+
+#: model:ir.model,name:mrp_lock_lot.model_stock_quant
+#. module: mrp_lock_lot
+msgid "Quants"
+msgstr "Quants"
+
+#: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
+#. module: mrp_lock_lot
+msgid "Unblock"
+msgstr "Débloquer"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "Unblock Serial Numbers/Lots"
+msgstr "Débloquer les Numéro de séries/lots"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "What do you want to do with selected Serial Numbers/Lots?"
+msgstr "Que souhaitez-vous faire sur les n° de série/lots sélectionnés ?"
+
+#: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
+#. module: mrp_lock_lot
+msgid "or"
+msgstr "ou"
+

--- a/mrp_lock_lot/i18n/mrp_lock_lot.pot
+++ b/mrp_lock_lot/i18n/mrp_lock_lot.pot
@@ -22,7 +22,7 @@ msgstr ""
 
 #. module: mrp_lock_lot
 #: field:product.category,lot_default_locked:0
-msgid "Create lot in locked status"
+msgid "Block new Serial Numbers/lots"
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -38,7 +38,7 @@ msgstr ""
 #. module: mrp_lock_lot
 #: code:addons/mrp_lock_lot/models/mrp_production_lot.py:43
 #, python-format
-msgid "Error!: Found stock movements for lot: \"%\" with location destination type in virtual/company"
+msgid "Error! Serial Number/Lot \"%s\" currently has reservations."
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -48,7 +48,7 @@ msgstr ""
 
 #. module: mrp_lock_lot
 #: help:product.category,lot_default_locked:0
-msgid "If checked, production lots will be created locked by default"
+msgid "If checked, future Serial Numbers/lots will be created blocked by default"
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -63,27 +63,27 @@ msgstr ""
 
 #. module: mrp_lock_lot
 #: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
-msgid "Lock"
+msgid "Block"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: view:product.category:mrp_lock_lot.product_category_form_view_inh_locklot
-msgid "Lock Lot Properties"
+msgid "Serial Nunber/lot blocking"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Lock lots"
+msgid "Block Serial Numbers/Lots"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: model:ir.actions.act_window,name:mrp_lock_lot.action_lock_lot
-msgid "Lock/Unlock lot"
+msgid "Block/Unblock Serial Number/lot"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Lock/Unlock lots"
+msgid "Block/Unblock Serial Numbers/lots"
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -91,7 +91,7 @@ msgstr ""
 #: field:stock.production.lot,locked:0
 #: view:stock.quant:mrp_lock_lot.quant_search_view_inh_locklot
 #: field:stock.quant,locked:0
-msgid "Locked"
+msgid "Blocked"
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -102,13 +102,13 @@ msgstr ""
 #. module: mrp_lock_lot
 #: model:mail.message.subtype,description:mrp_lock_lot.mt_lock_lot
 #: model:mail.message.subtype,name:mrp_lock_lot.mt_lock_lot
-msgid "Lot Locked"
+msgid "Serial Number/lot blocked"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: model:mail.message.subtype,description:mrp_lock_lot.mt_unlock_lot
 #: model:mail.message.subtype,name:mrp_lock_lot.mt_unlock_lot
-msgid "Lot Unlocked"
+msgid "Serial Number/lot unblocked"
 msgstr ""
 
 #. module: mrp_lock_lot
@@ -133,17 +133,17 @@ msgstr ""
 
 #. module: mrp_lock_lot
 #: view:stock.production.lot:mrp_lock_lot.view_production_lot_form_inh_locklot
-msgid "Unlock"
+msgid "Unblock"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "Unlock lots"
+msgid "Unblock Serial Numbers/Lots"
 msgstr ""
 
 #. module: mrp_lock_lot
 #: view:wiz.lock.lot:mrp_lock_lot.view_wiz_lock_lot_form
-msgid "What do you want to do with selected lots?"
+msgid "What do you want to do with selected Serial Numbers/Lots?"
 msgstr ""
 
 #. module: mrp_lock_lot

--- a/mrp_lock_lot/models/mrp_production_lot.py
+++ b/mrp_lock_lot/models/mrp_production_lot.py
@@ -40,7 +40,8 @@ class StockProductionLot(models.Model):
             for quant in stock_quant_obj.search(cond):
                 if quant.reservation_id.state not in ('cancel', 'done'):
                     raise exceptions.Warning(
-                        _('Error! Serial Number/Lot "%s" currently has reservations.')
+                        _('Error! Serial Number/Lot "%s" currently has '
+                          'reservations.')
                         % (lot.name))
         return self.write({'locked': True})
 

--- a/mrp_lock_lot/models/mrp_production_lot.py
+++ b/mrp_lock_lot/models/mrp_production_lot.py
@@ -23,7 +23,7 @@ class StockProductionLot(models.Model):
     def _get_locked_value(self):
         return self.product_id.categ_id.lot_default_locked
 
-    locked = fields.Boolean(string='Locked', default='_get_locked_value',
+    locked = fields.Boolean(string='Blocked', default='_get_locked_value',
                             readonly=True)
 
     @api.one
@@ -40,8 +40,7 @@ class StockProductionLot(models.Model):
             for quant in stock_quant_obj.search(cond):
                 if quant.reservation_id.state not in ('cancel', 'done'):
                     raise exceptions.Warning(
-                        _('Error!: Found stock movements for lot: "%" with'
-                          ' location destination type in virtual/company')
+                        _('Error! Serial Number/Lot "%s" currently has reservations.')
                         % (lot.name))
         return self.write({'locked': True})
 

--- a/mrp_lock_lot/models/product_category.py
+++ b/mrp_lock_lot/models/product_category.py
@@ -10,4 +10,5 @@ class ProductCategory(models.Model):
 
     lot_default_locked = fields.Boolean(
         string='Block new Serial Numbers/lots',
-        help='If checked, future Serial Numbers/lots will be created blocked by default')
+        help='If checked, future Serial Numbers/lots will be created blocked '
+             'by default')

--- a/mrp_lock_lot/models/product_category.py
+++ b/mrp_lock_lot/models/product_category.py
@@ -9,5 +9,5 @@ class ProductCategory(models.Model):
     _inherit = 'product.category'
 
     lot_default_locked = fields.Boolean(
-        string='Create lot in locked status',
-        help='If checked, production lots will be created locked by default')
+        string='Block new Serial Numbers/lots',
+        help='If checked, future Serial Numbers/lots will be created blocked by default')

--- a/mrp_lock_lot/models/stock_quant.py
+++ b/mrp_lock_lot/models/stock_quant.py
@@ -9,7 +9,7 @@ class StockQuant(models.Model):
     _inherit = 'stock.quant'
 
     locked = fields.Boolean(
-        string='Locked', related="lot_id.locked", default=False,
+        string='Blocked', related="lot_id.locked", default=False,
         store=True)
 
     def quants_get(self, cr, uid, location, product, qty, domain=None,

--- a/mrp_lock_lot/views/product_category_view.xml
+++ b/mrp_lock_lot/views/product_category_view.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//group[@name='parent']" position="inside">
-                        <group name="locklot_property" string="Lock Lot Properties" colspan="2">
+                        <group name="locklot_property" string="Serial Nunber/lot blocking" colspan="2">
                             <field name="lot_default_locked" />
                         </group>
                     </xpath>

--- a/mrp_lock_lot/views/stock_production_lot_view.xml
+++ b/mrp_lock_lot/views/stock_production_lot_view.xml
@@ -8,9 +8,9 @@
             <field name="arch" type="xml">
                 <div class="oe_button_box oe_right" position="before">
                     <header>
-                        <button name="button_lock" string="Lock"
+                        <button name="button_lock" string="Block"
                             type="object" attrs="{'invisible':[('locked','=',True)]}" />
-                        <button name="button_unlock" string="Unlock"
+                        <button name="button_unlock" string="Unblock"
                             type="object" attrs="{'invisible':[('locked','=',False)]}" />
                     </header>
                 </div>
@@ -55,7 +55,7 @@
                     <field name="locked" />
                 </field>
                 <filter string="Product" position="before">
-                    <filter string="Locked" domain="[]"
+                    <filter string="Blocked" domain="[]"
                         context="{'group_by':'locked'}" />
                 </filter>
             </field>

--- a/mrp_lock_lot/views/stock_quant_view.xml
+++ b/mrp_lock_lot/views/stock_quant_view.xml
@@ -10,7 +10,7 @@
                     <field name="locked" />
                 </field>
                 <filter string='Lot' position="after">
-                    <filter string='Locked' context="{'group_by' : 'locked'}" groups="stock.group_production_lot"/>
+                    <filter string='Blocked' context="{'group_by' : 'locked'}" groups="stock.group_production_lot"/>
                 </filter>
             </field>
         </record>

--- a/mrp_lock_lot/wizard/wiz_lock_lot_view.xml
+++ b/mrp_lock_lot/wizard/wiz_lock_lot_view.xml
@@ -6,11 +6,11 @@
             <field name="model">wiz.lock.lot</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <form string="Lock/Unlock lots">
-                    <label string="What do you want to do with selected lots?" colspan="4" />
+                <form string="Block/Unblock Serial Numbers/lots">
+                    <label string="What do you want to do with selected Serial Numbers/Lots?" colspan="4" />
                     <footer>
-                        <button class="oe_highlight" name="action_lock_lots" string="Lock lots" type="object" />
-                        <button class="oe_highlight" name="action_unlock_lots" string="Unlock lots" type="object" />
+                        <button class="oe_highlight" name="action_lock_lots" string="Block Serial Numbers/Lots" type="object" />
+                        <button class="oe_highlight" name="action_unlock_lots" string="Unblock Serial Numbers/Lots" type="object" />
                         or
                         <button class="oe_link" special="cancel" string="Cancel" />
                     </footer>
@@ -18,7 +18,7 @@
             </field>
         </record>
             <record id="action_lock_lot" model="ir.actions.act_window">
-            <field name="name">Lock/Unlock lot</field>
+            <field name="name">Block/Unblock Serial Number/lot</field>
             <field name="res_model">wiz.lock.lot</field>
             <field name="view_mode">tree,form</field>
             <field name="view_id" ref="view_wiz_lock_lot_form" />
@@ -27,7 +27,7 @@
 
         <record id="action_wizard_lock_lot" model="ir.values">
             <field name="model_id" ref="model_stock_production_lot" />
-            <field name="name">Lock/Unlock lot</field>
+            <field name="name">Block/Unblock Serial Number/lot</field>
             <field name="key2">client_action_multi</field>
             <field name="value"
                 eval="'ir.actions.act_window,' + str(ref('action_lock_lot'))" />


### PR DESCRIPTION
'Block' should be clearer than 'locked'.
The standard reads 'Serial Number/lot' instead of 'lot' since v7.
Removed unimplemented features from README.
