### PR TITLE
[FIX] Added item_id in tree view to correctly execution of onchange

### DIFF
--- a/sale_pricelist_rules/views/sale_view.xml
+++ b/sale_pricelist_rules/views/sale_view.xml
@@ -44,6 +44,7 @@
                             groups="product_pricelist_rules.group_third_discount" />
                         <field name="offer_id"
                             groups="sale.group_discount_per_so_line" />
+                        <field name="item_id" invisible="1"/>
                     </xpath>
                 </data>
             </field>


### PR DESCRIPTION
sale_pricelist_rules: If the item_id field is not present in tree view onchange function doesn't work properly.
