### PR TITLE
[FIX] supplierinfo for customer sequence workaround

### DIFF
--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -35,8 +35,19 @@ class ProductSupplierinfo(models.Model):
             return {'domain': {'name': [('customer', '=', True)]}}
         return {'domain': {'name': []}}
 
+    def _custumer_sequence_wa(self, vals):
+        si_type = vals['type'] if 'type' in vals else self.type
+        si_sequence = vals['sequence'] if 'sequence' in vals else self.sequence
+        if si_type == 'customer' and si_sequence < 100:
+            vals['sequence'] += 100
+        return vals
+
     @api.multi
-    @api.onchange('sequence')
-    def onchange_sequence(self):
-        if self.type == 'customer' and self.sequence < 100:
-            self.sequence += 100
+    def write(self, vals):
+        vals = self._custumer_sequence_wa(vals)
+        return super(ProductSupplierinfo, self).write(vals)
+
+    @api.model
+    def create(self, vals):
+        vals = self._custumer_sequence_wa(vals)
+        return super(ProductSupplierinfo, self).create(vals)

--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -35,19 +35,23 @@ class ProductSupplierinfo(models.Model):
             return {'domain': {'name': [('customer', '=', True)]}}
         return {'domain': {'name': []}}
 
-    def _custumer_sequence_wa(self, vals):
-        si_type = vals['type'] if 'type' in vals else self.type
-        si_sequence = vals['sequence'] if 'sequence' in vals else self.sequence
+    def _custumer_sequence_wa(self, vals, si_type, si_sequence):
         if si_type == 'customer' and si_sequence < 100:
-            vals['sequence'] += 100
+            si_sequence += 100
+        vals['type'] = si_type
+        vals['sequence'] = si_sequence
         return vals
 
     @api.multi
     def write(self, vals):
-        vals = self._custumer_sequence_wa(vals)
+        si_type = vals.get('type', self.type)
+        si_sequence = vals.get('sequence', self.sequence)
+        vals = self._custumer_sequence_wa(vals, si_type, si_sequence)
         return super(ProductSupplierinfo, self).write(vals)
 
     @api.model
     def create(self, vals):
-        vals = self._custumer_sequence_wa(vals)
+        si_type = vals.get('type', 'supplier')
+        si_sequence = vals.get('sequence', 1)
+        vals = self._custumer_sequence_wa(vals, si_type, si_sequence)
         return super(ProductSupplierinfo, self).create(vals)

--- a/product_supplierinfo_for_customer/models/product_supplierinfo.py
+++ b/product_supplierinfo_for_customer/models/product_supplierinfo.py
@@ -34,3 +34,9 @@ class ProductSupplierinfo(models.Model):
         elif self.type == 'customer':
             return {'domain': {'name': [('customer', '=', True)]}}
         return {'domain': {'name': []}}
+
+    @api.multi
+    @api.onchange('sequence')
+    def onchange_sequence(self):
+        if self.type == 'customer' and self.sequence < 100:
+            self.sequence += 100

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -57,6 +57,9 @@
             <field name="mode">primary</field>
             <field name="priority" eval="20" />
             <field name="arch" type="xml">
+                <field name="sequence" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
                 <field name="name" position="after">
                     <field name="product_tmpl_id" />
                 </field>
@@ -83,7 +86,12 @@
                     position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id,'default_sequence':99}">
+                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id,'default_sequence':101}">
+                        <tree>
+                            <field name="name"/>
+                            <field name="delay"/>
+                            <field name="min_qty"/>
+                        </tree>
                     </field>
                 </xpath>
             </field>

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -83,7 +83,7 @@
                     position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id}">
+                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id,'default_sequence':99}">
                     </field>
                 </xpath>
             </field>

--- a/product_supplierinfo_for_customer/views/product_view.xml
+++ b/product_supplierinfo_for_customer/views/product_view.xml
@@ -57,9 +57,6 @@
             <field name="mode">primary</field>
             <field name="priority" eval="20" />
             <field name="arch" type="xml">
-                <field name="sequence" position="attributes">
-                    <attribute name="invisible">1</attribute>
-                </field>
                 <field name="name" position="after">
                     <field name="product_tmpl_id" />
                 </field>
@@ -86,13 +83,8 @@
                     position="before">
                     <separator string="Customers" />
                     <field name="customer_ids"
-                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id,'default_sequence':101}">
-                        <tree>
-                            <field name="name"/>
-                            <field name="delay"/>
-                            <field name="min_qty"/>
-                        </tree>
-                    </field>
+                        context="{'default_search_type':'customer','default_type':'customer','default_product_tmpl_id':id,'default_sequence':101}"
+                        domain="[('type','=','customer')]" />
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Fix this issue: https://github.com/odoomrp/odoomrp-wip/issues/858
- Set an onchange method for 'sequence' field: When product.supplierinfo is type = 'customer' add to sequence 100, in order to not race with other product.supplierinfo records of type = 'supplier'
- Remove sequence column in customer_ids field and product.supplierinfo general tree view
