### PR TITLE
[FIX] procurement_plan_mrp: Display error if not defined the product …

### DIFF
--- a/procurement_plan_mrp/i18n/es.po
+++ b/procurement_plan_mrp/i18n/es.po
@@ -6,17 +6,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-18 12:59+0000\n"
-"PO-Revision-Date: 2015-05-18 12:59+0000\n"
-"Last-Translator: <>\n"
+"POT-Creation-Date: 2015-07-06 13:00+0000\n"
+"PO-Revision-Date: 2015-07-06 15:02+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:118
+#: code:addons/procurement_plan_mrp/models/procurement.py:119
 #, python-format
 msgid "BoM not found, for product: %s"
 msgstr "LdM no encontrada, para el producto: %s"
@@ -57,6 +57,12 @@ msgid "Manufacturing Order"
 msgstr "Órden de producción"
 
 #. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/models/procurement.py:171
+#, python-format
+msgid "No product defined for BoM line with template: %s, on the list of materials %s"
+msgstr "Producto no definido para línea de LdM con plantilla: %s, en la lista de materiales %s"
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 #: field:mrp.production,plan:0
 msgid "Plan"
@@ -83,7 +89,7 @@ msgid "Product"
 msgstr "Producto"
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:156
+#: code:addons/procurement_plan_mrp/models/procurement.py:157
 #, python-format
 msgid "Product has not been found on the list of materials %s, Level %s"
 msgstr "Producto no se ha encontrado en la lista de materiales %s, Nivel %s"
@@ -99,7 +105,7 @@ msgid "Purchase Orders"
 msgstr "Pedido de compra"
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:141
+#: code:addons/procurement_plan_mrp/models/procurement.py:142
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
 msgstr "NO SE HAN GENERADO TODOS LOS ABASTECIMIENTOS"

--- a/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
+++ b/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-18 12:58+0000\n"
-"PO-Revision-Date: 2015-05-18 12:58+0000\n"
+"POT-Creation-Date: 2015-07-06 13:00+0000\n"
+"PO-Revision-Date: 2015-07-06 13:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:118
+#: code:addons/procurement_plan_mrp/models/procurement.py:119
 #, python-format
 msgid "BoM not found, for product: %s"
 msgstr ""
@@ -57,6 +57,12 @@ msgid "Manufacturing Order"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/models/procurement.py:171
+#, python-format
+msgid "No product defined for BoM line with template: %s, on the list of materials %s"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 #: field:mrp.production,plan:0
 msgid "Plan"
@@ -83,7 +89,7 @@ msgid "Product"
 msgstr ""
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:156
+#: code:addons/procurement_plan_mrp/models/procurement.py:157
 #, python-format
 msgid "Product has not been found on the list of materials %s, Level %s"
 msgstr ""
@@ -99,7 +105,7 @@ msgid "Purchase Orders"
 msgstr ""
 
 #. module: procurement_plan_mrp
-#: code:addons/procurement_plan_mrp/models/procurement.py:141
+#: code:addons/procurement_plan_mrp/models/procurement.py:142
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
 msgstr ""


### PR DESCRIPTION
…in BoM line.

Módulo corregido para que muestre un error si no se ha definido el producto en la línea de la lista de materiales. Esto viene dado por un BUG reportado por Ana en el issue https://github.com/odoomrp/odoomrp-wip/issues/896
