### PR TITLE
[ADD] procurement_not_group_purchase_line: No increase amount in purc…

### DIFF
--- a/procurement_not_group_purchase_line/README.rst
+++ b/procurement_not_group_purchase_line/README.rst
@@ -1,0 +1,18 @@
+Procurement not group purchase line
+===================================
+
+This module defined in the product category "boolean" field "Group in
+purchase".
+If this new field is checked, to execute the procurement acts in a standard 
+adding the amount on line purchase order, but if it is not checked, a new line
+will be created in the purchase order.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <ajuaristo@gmail.com>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_not_group_purchase_line/__init__.py
+++ b/procurement_not_group_purchase_line/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models

--- a/procurement_not_group_purchase_line/__openerp__.py
+++ b/procurement_not_group_purchase_line/__openerp__.py
@@ -1,0 +1,35 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Procurement Not Group Purchase Line",
+    "version": "1.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Procurements",
+    "depends": ['purchase',
+                'sale',
+                'stock',
+                'procurement',
+                'product'
+                ],
+    "data": ['views/product_category_view.xml',
+             ],
+    "installable": True
+}

--- a/procurement_not_group_purchase_line/i18n/es.po
+++ b/procurement_not_group_purchase_line/i18n/es.po
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_not_group_purchase_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-13 10:21+0000\n"
+"PO-Revision-Date: 2015-07-13 12:23+0100\n"
+"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: procurement_not_group_purchase_line
+#: field:product.category,group_in_purchase:0
+msgid "Group in purchase"
+msgstr "Agrupar en compra"
+
+#. module: procurement_not_group_purchase_line
+#: help:product.category,group_in_purchase:0
+msgid "If the check is marked, running the procurement acts in a standard, adding the amount on line purchase order, but if it is not checked, a new line will be created in the purchase order."
+msgstr "Si el check está marcado, al ejecutar el abastecimiento actúa de forma estandar, sumando la cantidad en la línea del pedido de compra, pero si no está marcado, se creará una nueva línea en el pedido de compra."
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_product_category
+msgid "Product Category"
+msgstr "Categoría de producto"
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"
+

--- a/procurement_not_group_purchase_line/i18n/procurement_not_group_purchase_line.pot
+++ b/procurement_not_group_purchase_line/i18n/procurement_not_group_purchase_line.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* procurement_not_group_purchase_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-13 10:21+0000\n"
+"PO-Revision-Date: 2015-07-13 10:21+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: procurement_not_group_purchase_line
+#: field:product.category,group_in_purchase:0
+msgid "Group in purchase"
+msgstr ""
+
+#. module: procurement_not_group_purchase_line
+#: help:product.category,group_in_purchase:0
+msgid "If the check is marked, running the procurement acts in a standard, adding the amount on line purchase order, but if it is not checked, a new line will be created in the purchase order."
+msgstr ""
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_procurement_order
+msgid "Procurement"
+msgstr ""
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: procurement_not_group_purchase_line
+#: model:ir.model,name:procurement_not_group_purchase_line.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+

--- a/procurement_not_group_purchase_line/models/__init__.py
+++ b/procurement_not_group_purchase_line/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import product_category
+from . import procurement_order
+from . import purchase_order_line

--- a/procurement_not_group_purchase_line/models/procurement_order.py
+++ b/procurement_not_group_purchase_line/models/procurement_order.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def make_po(self):
+        res = super(
+            ProcurementOrder, self.with_context(from_make_po=True)).make_po()
+        return res

--- a/procurement_not_group_purchase_line/models/product_category.py
+++ b/procurement_not_group_purchase_line/models/product_category.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    group_in_purchase = fields.Boolean(
+        string='Group in purchase', default=True,
+        help='If the check is marked, running the procurement acts in a'
+        ' standard, adding the amount on line purchase order, but if it is not'
+        ' checked, a new line will be created in the purchase order.')

--- a/procurement_not_group_purchase_line/models/purchase_order_line.py
+++ b/procurement_not_group_purchase_line/models/purchase_order_line.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    def search(self, cr, uid, args, offset=0, limit=None, order=None,
+               context=None, count=False):
+        if context and context.get('from_make_po', False):
+            product_id = False
+            for arg in args:
+                if arg[0] == 'product_id':
+                    product_id = arg[2]
+            if product_id:
+                product = self.pool['product.product'].browse(
+                    cr, uid, product_id, context=context)
+                if not product.categ_id.group_in_purchase:
+                    return []
+        return super(PurchaseOrderLine, self).search(
+            cr, uid, args, offset=offset, limit=limit, order=order,
+            context=context, count=count)

--- a/procurement_not_group_purchase_line/views/product_category_view.xml
+++ b/procurement_not_group_purchase_line/views/product_category_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="product_category_form_view_inh_grouppurchaseline" model="ir.ui.view" >
+            <field name="name">product.category.form.view.inh.grouppurchaseline</field>
+            <field name="inherit_id" ref="product.product_category_form_view"/>
+            <field name="model">product.category</field>
+            <field name="arch" type="xml">
+                <field name="type" position="after">
+                    <field name="group_in_purchase" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
…hase order line, running the procurement.

Nuevo módulo para añadir un check en la categoría de producto "agrupar en compra", de tal forma que si el check está marcado, el ejecutar el abastecimiento actúe de forma standar sumando la cantidad en la línea del pedido de compra pero si no está marcado, se crearía una nueva línea en el pedido de compra.
Este nuevo requerimiento se ha solicitado en la reclamación CLM0141-Autofactura de Transportes
