### PR TITLE
[IMP] mrp_operations_extension: Put "mrp.workcenter" and "mrp.product…

### DIFF
--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -38,6 +38,7 @@
         "hr",
     ],
     "data": [
+        "data/mrp_operations_extension_data.xml",
         "wizard/mrp_workorder_produce_view.xml",
         "views/mrp_workcenter_view.xml",
         "views/mrp_routing_operation_view.xml",

--- a/mrp_operations_extension/data/mrp_operations_extension_data.xml
+++ b/mrp_operations_extension/data/mrp_operations_extension_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="req_link_mrp_workcenter" model="res.request.link">
+            <field name="name">Work Center</field>
+            <field name="object">mrp.workcenter</field>
+        </record>
+        <record id="req_link_mrp_workcenter" model="res.request.link">
+            <field name="name">Work Order</field>
+            <field name="object">mrp.production.workcenter.line</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…ion.workcenter.line" models, as referenceable models.

Modulo modificado para poner como referenciables los modelos "mrp.workcenter", y "mrp.production.workcenter.line". 
Este nuevo requisito se ha solicitado en la reclamación CLM0311-añadir concepto en reclamaciones.
