### PR TITLE
[FIX] purchase_product_variants: Avoids `expected singleton` error

### DIFF
--- a/purchase_product_variants/__openerp__.py
+++ b/purchase_product_variants/__openerp__.py
@@ -29,6 +29,7 @@
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "David Díaz <d.diazp@gmail.com>",
     ],
     "category": "Custom Module",
     "website": "http://www.odoomrp.com",

--- a/purchase_product_variants/models/purchase_order.py
+++ b/purchase_product_variants/models/purchase_order.py
@@ -34,7 +34,13 @@ class PurchaseOrder(models.Model):
                 domain = [('product_tmpl_id', '=', line.product_template.id)]
                 for value in att_values_ids:
                     domain.append(('attribute_value_ids', '=', value))
-                product = product_obj.search(domain)
+                products = product_obj.search(domain)
+                # Filter the product with the exact number of attributes values
+                product = False
+                for prod in products:
+                    if len(prod.attribute_value_ids) == len(att_values_ids):
+                        product = prod
+                        break
                 if not product:
                     product = product_obj.create(
                         {'product_tmpl_id': line.product_template.id,


### PR DESCRIPTION
Checks the number of attributes selected in `purchase.order.line` and the corresponding `product.product` to ensure to be equal and avoid `expected singleton` error.
