### PR TITLE
[FIX] mrp_subcontracting: Put source locations, and correct destinati…

### DIFF
--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -38,6 +38,7 @@
         "hr",
     ],
     "data": [
+        "data/mrp_operations_extension_data.xml",
         "wizard/mrp_workorder_produce_view.xml",
         "views/mrp_workcenter_view.xml",
         "views/mrp_routing_operation_view.xml",

--- a/mrp_operations_extension/data/mrp_operations_extension_data.xml
+++ b/mrp_operations_extension/data/mrp_operations_extension_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="req_link_mrp_workcenter" model="res.request.link">
+            <field name="name">Work Center</field>
+            <field name="object">mrp.workcenter</field>
+        </record>
+        <record id="req_link_mrp_workcenter" model="res.request.link">
+            <field name="name">Work Order</field>
+            <field name="object">mrp.production.workcenter.line</field>
+        </record>
+    </data>
+</openerp>

--- a/mrp_operations_extension/models/mrp_routing.py
+++ b/mrp_operations_extension/models/mrp_routing.py
@@ -56,6 +56,8 @@ class MrpRoutingWorkcenter(models.Model):
     previous_operations_finished = fields.Boolean(
         string='Previous operations finished',
         default="get_routing_previous_operations")
+    picking_type_id = fields.Many2one('stock.picking.type', 'Picking Type',
+                                      domain=[('code', '=', 'outgoing')])
 
     @api.constrains('op_wc_lines')
     def _check_default_op_wc_lines(self):

--- a/mrp_subcontracting/__init__.py
+++ b/mrp_subcontracting/__init__.py
@@ -1,19 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from . import models
+from . import wizard

--- a/mrp_subcontracting/__openerp__.py
+++ b/mrp_subcontracting/__openerp__.py
@@ -34,6 +34,7 @@
                 'mrp',
                 'mrp_operations',
                 'mrp_operations_extension',
+                'mrp_production_add_middle_stuff_operations'
                 ],
     "data": ['views/stock_picking_view.xml',
              'views/purchase_order_view.xml',

--- a/mrp_subcontracting/__openerp__.py
+++ b/mrp_subcontracting/__openerp__.py
@@ -34,7 +34,6 @@
                 'mrp',
                 'mrp_operations',
                 'mrp_operations_extension',
-                'mrp_production_add_middle_stuff_operations'
                 ],
     "data": ['views/stock_picking_view.xml',
              'views/purchase_order_view.xml',

--- a/mrp_subcontracting/models/mrp_production.py
+++ b/mrp_subcontracting/models/mrp_production.py
@@ -43,7 +43,8 @@ class MrpProduction(models.Model):
     def action_confirm(self):
         res = super(MrpProduction, self).action_confirm()
         for move in self.move_lines:
-            if move.work_order.routing_wc_line.external:
+            if (move.work_order.routing_wc_line.external and
+                    move.work_order.routing_wc_line.picking_type_id):
                 ptype = move.work_order.routing_wc_line.picking_type_id
                 move.location_id = ptype.default_location_src_id.id
                 move.location_dest_id = ptype.default_location_dest_id.id
@@ -61,7 +62,8 @@ class MrpProduction(models.Model):
             production, product, uom_id, qty, uos_id, uos_qty)
         if 'work_order' in self.env.context:
             work_order = self.env.context.get('work_order')
-            if work_order.routing_wc_line.external:
+            if (work_order.routing_wc_line.external and
+                    work_order.routing_wc_line.picking_type_id):
                 picking_type = work_order.routing_wc_line.picking_type_id
                 vals = {'location_id': picking_type.default_location_src_id.id,
                         'location_dest_id':

--- a/mrp_subcontracting/models/mrp_production.py
+++ b/mrp_subcontracting/models/mrp_production.py
@@ -1,21 +1,7 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-
 from openerp import models, fields, api
 
 
@@ -66,6 +52,23 @@ class MrpProduction(models.Model):
                 wc_line.procurement_order = (
                     self._create_external_procurement(wc_line))
         return res
+
+    @api.model
+    def _make_consume_line_from_data(self, production, product, uom_id, qty,
+                                     uos_id, uos_qty):
+        move_obj = self.env['stock.move']
+        move_id = super(MrpProduction, self)._make_consume_line_from_data(
+            production, product, uom_id, qty, uos_id, uos_qty)
+        if 'work_order' in self.env.context:
+            work_order = self.env.context.get('work_order')
+            if work_order.routing_wc_line.external:
+                picking_type = work_order.routing_wc_line.picking_type_id
+                vals = {'location_id': picking_type.default_location_src_id.id,
+                        'location_dest_id':
+                        picking_type.default_location_dest_id.id}
+                move = move_obj.browse(move_id)
+                move.write(vals)
+        return move_id
 
     def _prepare_extenal_procurement(self, wc_line):
         wc = wc_line.routing_wc_line

--- a/mrp_subcontracting/models/mrp_routing_workcenter.py
+++ b/mrp_subcontracting/models/mrp_routing_workcenter.py
@@ -1,19 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from openerp import models, fields
 

--- a/mrp_subcontracting/models/mrp_routing_workcenter.py
+++ b/mrp_subcontracting/models/mrp_routing_workcenter.py
@@ -11,5 +11,3 @@ class MrpRoutingWorkcenter(models.Model):
     external = fields.Boolean('External', help="Is Subcontract Operation")
     semifinished_id = fields.Many2one(
         comodel_name='product.product', string='Semifinished Subcontracting')
-    picking_type_id = fields.Many2one('stock.picking.type', 'Picking Type',
-                                      domain=[('code', '=', 'outgoing')])

--- a/mrp_subcontracting/models/procurement_order.py
+++ b/mrp_subcontracting/models/procurement_order.py
@@ -1,19 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from openerp import models, fields, api
 

--- a/mrp_subcontracting/models/purchase_order.py
+++ b/mrp_subcontracting/models/purchase_order.py
@@ -1,19 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from openerp import models, fields, api
 

--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -1,19 +1,6 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
+# For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from openerp import models, fields
 

--- a/mrp_subcontracting/wizard/__init__.py
+++ b/mrp_subcontracting/wizard/__init__.py
@@ -2,8 +2,4 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from . import purchase_order
-from . import stock_picking
-from . import procurement_order
-from . import mrp_production
-from . import mrp_routing_workcenter
+from . import wizard_addition

--- a/mrp_subcontracting/wizard/wizard_addition.py
+++ b/mrp_subcontracting/wizard/wizard_addition.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class WizProductionProductLine(models.TransientModel):
+    _inherit = 'wiz.production.product.line'
+
+    @api.multi
+    def add_product(self):
+        return super(
+            WizProductionProductLine,
+            self.with_context(work_order=self.work_order)).add_product()


### PR DESCRIPTION
…on, where products are added to an operation.

Se ha arreglado un BUG reportado por Ana. El caso es que cuando se estaban añadiendo productos a una operación de subcontratación, se estaban añadiendo mal las ubicaciones al nuevo movimiento que se estaba dando de alta.
Este BUG lo reportó Ana en el issue https://github.com/odoomrp/odoomrp-wip/issues/918
