### PR TITLE
[FIX] mrp_operations_extension Fixes #920 Now initiate a WO doesn't force MO material reservation

### DIFF
--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -154,4 +154,6 @@ class MrpProductionWorkcenterLine(models.Model):
                                                  'done']):
             raise exceptions.Warning(
                 _("Missing materials to start the production"))
+        if self.production_id.state == 'confirmed':
+            self.production_id.state = 'ready'
         return super(MrpProductionWorkcenterLine, self).action_start_working()


### PR DESCRIPTION
Now initiate a WO doesn't force MO material reservation
