### PR TITLE
[FIX] mrp_configurable timing: llamada correcta al super en la función _get_workorder_in_product_lines

### DIFF
--- a/mrp_configurable_timing/models/mrp_production.py
+++ b/mrp_configurable_timing/models/mrp_production.py
@@ -29,7 +29,8 @@ class MrpProduction(models.Model):
 
     def _get_workorder_in_product_lines(
             self, workcenter_lines, product_lines, properties=None):
-        super(MrpProduction, self)._get_workorder_in_product_lines
+        super(MrpProduction, self)._get_workorder_in_product_lines(
+            workcenter_lines, product_lines, properties=properties)
         for workorder in workcenter_lines:
             wc = workorder.routing_wc_line
             cycle = wc.cycle_nbr and (self.product_qty / wc.cycle_nbr) or 0

--- a/mrp_product_variants_configurable_timing/models/mrp_production.py
+++ b/mrp_product_variants_configurable_timing/models/mrp_production.py
@@ -26,7 +26,8 @@ class MrpProduction(models.Model):
 
     def _get_workorder_in_product_lines(
             self, workcenter_lines, product_lines, properties=None):
-        super(MrpProduction, self)._get_workorder_in_product_lines
+        super(MrpProduction, self)._get_workorder_in_product_lines(
+            workcenter_lines, product_lines, properties=properties)
         for workorder in workcenter_lines:
             wc = workorder.routing_wc_line
             cycle = wc.cycle_nbr and (self.product_qty / wc.cycle_nbr) or 0


### PR DESCRIPTION
[FIX] mrp_product_variants_configurable_timing: llamada super en función _get_workorder_in_product_lines
