### PR TITLE
[FIX] stock_quant_merge: Rewrite the merge method

### DIFF
--- a/stock_quant_merge/README.rst
+++ b/stock_quant_merge/README.rst
@@ -1,7 +1,7 @@
 Quant merge
 ===========
 
-This module allows to merge diferent quants if they meet some requirements.
+This module Re-merges previously split quants after canceling reservation.
 
 
 Credits
@@ -12,3 +12,4 @@ Contributors
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <ajuaristio@gmail.com>
+* Mohammad Alhashash (Centrivision)

--- a/stock_quant_merge/__openerp__.py
+++ b/stock_quant_merge/__openerp__.py
@@ -22,17 +22,19 @@
     "depends": [
         "stock",
     ],
-    "author": "OdooMRP team,"
-              "AvanzOSC,"
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "author": "OdooMRP team, "
+              "AvanzOSC, "
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Centrivision",
     "website": "http://www.odoomrp.com",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
-        "Ana Juaristi <ajuaristio@gmail.com>"
+        "Ana Juaristi <ajuaristio@gmail.com>",
+        "Mohammad Alhashash <alhashash@alhashash.net>"
     ],
     "category": "Warehouse Management",
-    "summary": "",
+    "summary": "Re-merge previously split quants after canceling reservation",
     "data": [],
     "installable": True,
 }


### PR DESCRIPTION
- Match the complete history, not just the last move
- Fix incorrect cost calculation (weighted average instead of average)
- Single write call instead of using the "active record" interface
- Ignore negative quants

I'm still not sure about the cost; I think we should match the cost in the search condition. I do not think there is any case where the cost of split quants can diverge without stock moves.
