### PR TITLE
[FIX] Inventory Import with location in csv

### DIFF
--- a/stock_inventory_import/wizard/import_inventory.py
+++ b/stock_inventory_import/wizard/import_inventory.py
@@ -73,7 +73,7 @@ class ImportInventory(models.TransientModel):
                 locat_lst = stloc_obj.search([('name', '=',
                                                values['location'])])
                 if locat_lst:
-                    prod_location = locat_lst[0]
+                    prod_location = locat_lst[0].id
             prod_lst = product_obj.search([('default_code', '=',
                                             values['code'])])
             if prod_lst:

--- a/stock_inventory_import/wizard/import_inventory.py
+++ b/stock_inventory_import/wizard/import_inventory.py
@@ -70,10 +70,9 @@ class ImportInventory(models.TransientModel):
             values = dict(zip(keys, field))
             prod_location = location.id
             if 'location' in values and values['location']:
-                locat_lst = stloc_obj.search([('name', '=',
+                locations = stloc_obj.search([('name', '=',
                                                values['location'])])
-                if locat_lst:
-                    prod_location = locat_lst[0].id
+                prod_location = locations[:1].id
             prod_lst = product_obj.search([('default_code', '=',
                                             values['code'])])
             if prod_lst:

--- a/stock_inventory_import/wizard/import_inventory_view.xml
+++ b/stock_inventory_import/wizard/import_inventory_view.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <form string="Import Inventory">
                 <label string="The file must have 2 column keys:
-                'code' => for product referente
+                'code' => for product reference
                 'quantity' => for product quantity" colspan="4"/>
                     <group colspan="4" col="4">
                         <field name="name" />


### PR DESCRIPTION
Propongo solución para un error que salta al importar un inventario desde csv cuando se incluye la ubicación en el archivo.

Pasos para reproducir el error:
- Tener instalado el stock_inventory_import
- Ir a Almacén/Ajustes de inventario y crear un inventario.
- Seleccionar la opción _By File_
- Cargar un archivo con las columnas _code_, _quantity_, _location_

Salta un error: _ProgrammingError: can't adapt type 'stock.location'_
