### PR TITLE
[IMP] mrp_operations_extension: nuevas funcionalidades en workorders

### DIFF
--- a/mrp_operations_extension/views/mrp_production_view.xml
+++ b/mrp_operations_extension/views/mrp_production_view.xml
@@ -225,5 +225,19 @@
                 </field>
             </field>
         </record>
+
+    <record id="workcenter_line_future_calendar" model="ir.ui.view">
+        <field name="name">mrp.production.workcenter.line.future.calendar</field>
+        <field name="model">mrp.production.workcenter.line</field>
+        <field name="priority" eval="10"/>
+        <field name="arch" type="xml">
+            <calendar color="production_id" date_stop="date_planned_end" date_start="date_planned" string="Operations">
+                <field name="workcenter_id"/>
+                <field name="production_id"/>
+                <field name="product"/>
+            </calendar>
+        </field>
+    </record>
+
     </data>
 </openerp>


### PR DESCRIPTION
Closes #750 #812 - Se han realizado solo algunos puntos del issue ya que algunos de ellos se han solucionado en las nuevas actualizaciones
    - nueva vista calendario, según fechas previstas
    - permitir modificar la fecha planificada de una OF si no está iniciada
    - cambiar la fecha prevista de una OF cuando se cambia la fecha prevista de una OT si esta es menor que la de su OF
