### PR TITLE
[IMP] procurement_plan: They can be selected only procurements with "…

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,6 +1,7 @@
 # List the OdooMRP project dependencies, one per line
 odoomrp-utils
 # List the OCA project dependencies, one per line
+stock-logistics-warehouse https://github.com/OCA/stock-logistics-warehouse.git
 crm https://github.com/OCA/crm
 manufacture https://github.com/OCA/manufacture
 sale-workflow https://github.com/OCA/sale-workflow

--- a/procurement_plan/wizard/wiz_import_procurement_from_plan.py
+++ b/procurement_plan/wizard/wiz_import_procurement_from_plan.py
@@ -32,6 +32,7 @@ class WizImportProcurementFromPlan(models.TransientModel):
         self.ensure_one()
         cond = [('warehouse_id', '=', self.warehouse_id.id),
                 ('state', 'not in', ('cancel', 'done')),
+                ('location_type', '=', 'internal'),
                 ('plan', '=', False)]
         if self.from_date:
             cond.append(('date_planned', '>=', self.from_date))

--- a/procurement_plan/wizard/wiz_import_procurement_from_plan_view.xml
+++ b/procurement_plan/wizard/wiz_import_procurement_from_plan_view.xml
@@ -10,7 +10,7 @@
                     <field name="to_date" invisible="1" />
                     <field name="warehouse_id" invisible="1" />
                     <separator string="Procurements"/>
-                    <field name="procurement_ids" height="300" width="700" />
+                    <field name="procurement_ids" height="300" width="700"/>
                     <footer>
                         <button name="import_procurements" type="object" 
                                 string="Import" class="oe_highlight" />

--- a/procurement_plan_mrp/README.rst
+++ b/procurement_plan_mrp/README.rst
@@ -9,6 +9,10 @@ You can import procurements with "Internal" location, and then click the
 button "Generate procurements", what it does is generate procurements for all
 products that are needed in the production of this final product.
 
+Also, by confirming a sales order, if a procurement order of a product to
+produce is generated, procurement plan is automatically created for that
+procurement order, and also automatically creates lower levels of the same.
+
 Credits
 =======
 

--- a/procurement_plan_mrp/__openerp__.py
+++ b/procurement_plan_mrp/__openerp__.py
@@ -25,8 +25,11 @@
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
     "website": "http://www.odoomrp.com",
     "category": "Manufacturing",
-    "depends": ['mrp',
+    "depends": ['sale',
+                'mrp',
                 'procurement_plan',
+                'stock_reserve',
+                'sale_mrp_project_link'
                 ],
     "data": ['views/mrp_production_view.xml',
              'views/procurement_plan_view.xml',

--- a/procurement_plan_mrp/i18n/es.po
+++ b/procurement_plan_mrp/i18n/es.po
@@ -1,22 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* procurement_plan_mrp
+# 	* procurement_plan_mrp
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-06 13:00+0000\n"
-"PO-Revision-Date: 2015-07-06 15:02+0100\n"
-"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"POT-Creation-Date: 2015-10-06 08:00+0000\n"
+"PO-Revision-Date: 2015-10-06 10:01+0100\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:119
+#: code:addons/procurement_plan_mrp/models/procurement.py:155
 #, python-format
 msgid "BoM not found, for product: %s"
 msgstr "LdM no encontrada, para el producto: %s"
@@ -37,6 +39,12 @@ msgid "Generate procurements"
 msgstr "Generar abastecimientos"
 
 #. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/models/procurement.py:105
+#, python-format
+msgid "Generated from sale order: "
+msgstr "Generado desde el pedido de venta: "
+
+#. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Import Procurements"
 msgstr "Importar abastecimientos"
@@ -54,13 +62,18 @@ msgstr "Órdenes de Producción"
 #. module: procurement_plan_mrp
 #: model:ir.model,name:procurement_plan_mrp.model_mrp_production
 msgid "Manufacturing Order"
-msgstr "Órden de producción"
+msgstr "Orden de fabricación"
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:171
+#: code:addons/procurement_plan_mrp/models/procurement.py:208
 #, python-format
-msgid "No product defined for BoM line with template: %s, on the list of materials %s"
-msgstr "Producto no definido para línea de LdM con plantilla: %s, en la lista de materiales %s"
+msgid ""
+"No product defined for BoM line with template: %s, on the list of materials "
+"%s"
+msgstr ""
+"Producto no definido para línea de LdM con plantilla: %s, en la lista de "
+"materiales %s"
 
 #. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
@@ -84,12 +97,18 @@ msgid "Procurement Plan"
 msgstr "Plan abastecimientos"
 
 #. module: procurement_plan_mrp
+#: field:stock.reservation,procurement_from_plan:0
+msgid "Procurement from plan"
+msgstr "Abastecimiento desde plan"
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 msgid "Product"
 msgstr "Producto"
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:157
+#: code:addons/procurement_plan_mrp/models/procurement.py:193
 #, python-format
 msgid "Product has not been found on the list of materials %s, Level %s"
 msgstr "Producto no se ha encontrado en la lista de materiales %s, Nivel %s"
@@ -105,8 +124,23 @@ msgid "Purchase Orders"
 msgstr "Pedido de compra"
 
 #. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_stock_reservation
+msgid "Stock Reservation"
+msgstr "Reserva de existencias"
+
+#. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:142
+#: code:addons/procurement_plan_mrp/models/procurement.py:178
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
 msgstr "NO SE HAN GENERADO TODOS LOS ABASTECIMIENTOS"
-

--- a/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
+++ b/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-06 13:00+0000\n"
-"PO-Revision-Date: 2015-07-06 13:00+0000\n"
+"POT-Creation-Date: 2015-10-06 08:00+0000\n"
+"PO-Revision-Date: 2015-10-06 08:00+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:119
+#: code:addons/procurement_plan_mrp/models/procurement.py:155
 #, python-format
 msgid "BoM not found, for product: %s"
 msgstr ""
@@ -34,6 +35,12 @@ msgstr ""
 #. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Generate procurements"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/models/procurement.py:105
+#, python-format
+msgid "Generated from sale order: "
 msgstr ""
 
 #. module: procurement_plan_mrp
@@ -58,6 +65,7 @@ msgstr ""
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:171
+#: code:addons/procurement_plan_mrp/models/procurement.py:208
 #, python-format
 msgid "No product defined for BoM line with template: %s, on the list of materials %s"
 msgstr ""
@@ -84,12 +92,18 @@ msgid "Procurement Plan"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: field:stock.reservation,procurement_from_plan:0
+msgid "Procurement from plan"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 msgid "Product"
 msgstr ""
 
 #. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:157
+#: code:addons/procurement_plan_mrp/models/procurement.py:193
 #, python-format
 msgid "Product has not been found on the list of materials %s, Level %s"
 msgstr ""
@@ -105,7 +119,23 @@ msgid "Purchase Orders"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: model:ir.model,name:procurement_plan_mrp.model_stock_reservation
+msgid "Stock Reservation"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:142
+#: code:addons/procurement_plan_mrp/models/procurement.py:178
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
 msgstr ""

--- a/procurement_plan_mrp/models/sale_order.py
+++ b/procurement_plan_mrp/models/sale_order.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def action_ship_create(self):
+        result = super(SaleOrder, self).action_ship_create()
+        for order in self:
+            for line in order.order_line:
+                if (self.env.ref('mrp.route_warehouse0_manufacture').id in
+                        line.product_id.route_ids.ids):
+                    line._find_mrp_procurement_with_level0()
+        return result
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.one
+    def _find_mrp_procurement_with_level0(self):
+        proc_obj = self.env['procurement.order']
+        cond = [('sale_line_id', '=', self.id)]
+        procurement = proc_obj.search(cond, limit=1)
+        if procurement:
+            cond = [('id', '!=', procurement.id),
+                    ('group_id', '=', procurement.group_id.id),
+                    ('product_id', '=', procurement.product_id.id),
+                    ('product_qty', '=', self.product_uom_qty),
+                    ('production_id', '!=', False),
+                    ('plan', '=', False),
+                    ('level', '=', 0)]
+            procurement = proc_obj.search(cond, limit=1)
+            if procurement:
+                procurement._create_procurement_plan_from_procurement(
+                    self.order_id)

--- a/procurement_plan_mrp/models/stock_reservation.py
+++ b/procurement_plan_mrp/models/stock_reservation.py
@@ -2,7 +2,10 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from . import procurement
-from . import mrp_production
-from . import stock_reservation
-from . import sale_order
+from openerp import models, fields
+
+
+class StockReservation(models.Model):
+    _inherit = 'stock.reservation'
+    procurement_from_plan = fields.Many2one(
+        'procurement.order', string='Procurement from plan')


### PR DESCRIPTION
…location_type" equal to "internal".

[IMP] procurement_plan_mrp: By confirming a sales order, if a procurement order of a product to produce is generated, procurement plan is automatically created for that procurement order, and also automatically creates lower levels of the same.

procurement_plan: Que se puedan seleccionar solo abastecimientos con "location_type" igual a "internal".
procurement_plan_mrp: También, al confirmar un pedido de venta, si se genera un abastecimiento de un producto a producir, se crea un plan de abastecimientos automáticamente para dicho abastecimiento, y también crea automáticamente los niveles inferiores del mismo.
