### PR TITLE
[IMP] purchase_priceslit_rules: campos totales de pedido de compra, campos calculados con la nueva api

### DIFF
--- a/purchase_pricelist_rules/__openerp__.py
+++ b/purchase_pricelist_rules/__openerp__.py
@@ -29,6 +29,7 @@
     "author": "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "license": "AGPL-3",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",


### PR DESCRIPTION
Hemos detectado un bug.
Si generamos un Pedido de compra con varias líneas, y el importe de ellos a 0. Cuando reabrimos este pedido para introducir los importes correctos, al guardar, los totales solo muestran la suma de la primera línea.
Para que nos coja los importes correctos, debemos volver a abrir el pedido y modificar de nuevo el importe de las líneas.
Por ello, he replicado los campos de totales del pedido, y los he pasado a la nueva API.
