### PR TITLE
[IMP] procurement_plan: wizard for change procurement date_planned.

### DIFF
--- a/procurement_plan/__openerp__.py
+++ b/procurement_plan/__openerp__.py
@@ -37,6 +37,7 @@
              'wizard/wiz_import_procurement_from_plan_view.xml',
              'wizard/wiz_load_sale_from_plan_view.xml',
              'wizard/wiz_load_purchase_from_plan_view.xml',
+             'wizard/wiz_change_procurement_date_view.xml',
              'views/procurement_view.xml',
              'views/procurement_view.xml',
              'views/procurement_plan_view.xml',

--- a/procurement_plan/i18n/es.po
+++ b/procurement_plan/i18n/es.po
@@ -1,22 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* procurement_plan
+# 	* procurement_plan
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-18 17:47+0000\n"
-"PO-Revision-Date: 2015-05-18 19:49+0100\n"
-"Last-Translator: Alfredo <alfredodelafuente@avanzosc.com>\n"
+"POT-Creation-Date: 2015-11-02 15:24+0000\n"
+"PO-Revision-Date: 2015-11-02 16:28+0100\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
 
 #. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
 #: view:wiz.import.procurement.from.plan:procurement_plan.wiz_import_procurement_from_plan_view
 #: view:wiz.load.purchase.from.plan:procurement_plan.wiz_load_purchase_from_plan_view
 #: view:wiz.load.sale.from.plan:procurement_plan.wiz_load_sale_from_plan_view
@@ -35,12 +37,18 @@ msgid "Category"
 msgstr "Categoría"
 
 #. module: procurement_plan
+#: model:ir.actions.act_window,name:procurement_plan.action_change_procurement_scheduled_date
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid "Change scheduled date"
+msgstr "Cambiar fecha planificada"
+
+#. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
 msgid "Check Procurements"
 msgstr "Comprobar abastecimientos"
 
 #. module: procurement_plan
-#: field:procurement.plan,create_uid:0
+#: field:wiz.change.procurement.date,create_uid:0
 #: field:wiz.import.procurement.from.plan,create_uid:0
 #: field:wiz.load.purchase.from.plan,create_uid:0
 #: field:wiz.load.sale.from.plan,create_uid:0
@@ -48,7 +56,7 @@ msgid "Created by"
 msgstr "Creado por"
 
 #. module: procurement_plan
-#: field:procurement.plan,create_date:0
+#: field:wiz.change.procurement.date,create_date:0
 #: field:wiz.import.procurement.from.plan,create_date:0
 #: field:wiz.load.purchase.from.plan,create_date:0
 #: field:wiz.load.sale.from.plan,create_date:0
@@ -100,6 +108,12 @@ msgid "Error!: End date is lower than start date."
 msgstr "Error!: Fecha fin es menor que fecha comienzo."
 
 #. module: procurement_plan
+#: code:addons/procurement_plan/wizard/wiz_change_procurement_date.py:43
+#, python-format
+msgid "Error!: No procurements found to treat."
+msgstr "Error!: No se han encontrado abastecimientos a tratar"
+
+#. module: procurement_plan
 #: code:addons/procurement_plan/models/procurement_plan.py:81
 #: code:addons/procurement_plan/models/procurement_plan.py:106
 #, python-format
@@ -137,14 +151,17 @@ msgstr "Agrupar por"
 
 #. module: procurement_plan
 #: help:procurement.plan,message_summary:0
-msgid "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
-msgstr "Resumen del chat (número de mensajes, ...). Este resumen es directamente en formato html para ser insertada en vistas kanban."
+msgid ""
+"Holds the Chatter summary (number of messages, ...). This summary is "
+"directly in html format in order to be inserted in kanban views."
+msgstr ""
+"Resumen del chat (número de mensajes, ...). Este resumen es directamente en "
+"formato html para ser insertada en vistas kanban."
 
 #. module: procurement_plan
-#: field:procurement.plan,id:0
+#: field:wiz.change.procurement.date,id:0
 #: field:wiz.import.procurement.from.plan,id:0
-#: field:wiz.load.purchase.from.plan,id:0
-#: field:wiz.load.sale.from.plan,id:0
+#: field:wiz.load.purchase.from.plan,id:0 field:wiz.load.sale.from.plan,id:0
 msgid "ID"
 msgstr "ID"
 
@@ -179,7 +196,7 @@ msgid "Last Message Date"
 msgstr "Fecha último mensaje"
 
 #. module: procurement_plan
-#: field:procurement.plan,write_uid:0
+#: field:wiz.change.procurement.date,write_uid:0
 #: field:wiz.import.procurement.from.plan,write_uid:0
 #: field:wiz.load.purchase.from.plan,write_uid:0
 #: field:wiz.load.sale.from.plan,write_uid:0
@@ -187,7 +204,7 @@ msgid "Last Updated by"
 msgstr "Última actualización por"
 
 #. module: procurement_plan
-#: field:procurement.plan,write_date:0
+#: field:wiz.change.procurement.date,write_date:0
 #: field:wiz.import.procurement.from.plan,write_date:0
 #: field:wiz.load.purchase.from.plan,write_date:0
 #: field:wiz.load.sale.from.plan,write_date:0
@@ -236,6 +253,16 @@ msgstr "Mensajes"
 #: help:procurement.plan,message_ids:0
 msgid "Messages and communication history"
 msgstr "Mensajes e historia de comunicación"
+
+#. module: procurement_plan
+#: field:wiz.change.procurement.date,new_scheduled_date:0
+msgid "New scheduled date"
+msgstr "Fecha plafinicación nueva"
+
+#. module: procurement_plan
+#: field:wiz.change.procurement.date,old_scheduled_date:0
+msgid "Old scheduled date"
+msgstr "Fecha planificación vieja"
 
 #. module: procurement_plan
 #: view:procurement.order:procurement_plan.view_procurement_filter_inh_withplan
@@ -287,10 +314,23 @@ msgid "Procurements Plans"
 msgstr "Planes de abastecimientos"
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+#: field:wiz.change.procurement.date,procurements:0
+msgid "Procurements to treat"
+msgstr "Abastecimientos a tratar"
+
+#. module: procurement_plan
 #: field:wiz.load.purchase.from.plan,product_id:0
 #: field:wiz.load.sale.from.plan,product_id:0
 msgid "Product"
 msgstr "Producto"
+
+#. module: procurement_plan
+#: code:addons/procurement_plan/wizard/wiz_load_purchase_from_plan.py:102
+#: code:addons/procurement_plan/wizard/wiz_load_sale_from_plan.py:104
+#, python-format
+msgid "Product UOM or Product UOS not found for product: %s"
+msgstr "Product UOM o Product UOS no encontrado para el producto: %s"
 
 #. module: procurement_plan
 #: field:procurement.plan,project_id:0
@@ -308,6 +348,11 @@ msgstr "Compra"
 #: field:procurement.plan,purchase_ids:0
 msgid "Purchase Orders"
 msgstr "Pedido de compra"
+
+#. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid "Put a new scheduled date in procurements"
+msgstr "Poner una nueva fecha planificación en abastecimientos"
 
 #. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
@@ -377,6 +422,15 @@ msgid "Template"
 msgstr "Plantilla"
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid ""
+"They treated procurements of type INTERNAL, without purchases, or with "
+"purchases with state DRAFT."
+msgstr ""
+"Se tratan abastecimientos de tipo INTERNO, sin compras, o con compras en "
+"estado BORRADOR."
+
+#. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
 msgid "Unit of Measure"
 msgstr "Unidad de medida"
@@ -423,6 +477,7 @@ msgid "name"
 msgstr "descripción"
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
 #: view:wiz.import.procurement.from.plan:procurement_plan.wiz_import_procurement_from_plan_view
 #: view:wiz.load.purchase.from.plan:procurement_plan.wiz_load_purchase_from_plan_view
 #: view:wiz.load.sale.from.plan:procurement_plan.wiz_load_sale_from_plan_view
@@ -434,4 +489,3 @@ msgstr "o"
 #: field:wiz.import.procurement.from.plan,to_date:0
 msgid "to Date"
 msgstr "Hasta fecha"
-

--- a/procurement_plan/i18n/procurement_plan.pot
+++ b/procurement_plan/i18n/procurement_plan.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-18 17:46+0000\n"
-"PO-Revision-Date: 2015-05-18 17:46+0000\n"
+"POT-Creation-Date: 2015-11-02 15:23+0000\n"
+"PO-Revision-Date: 2015-11-02 15:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
 #: view:wiz.import.procurement.from.plan:procurement_plan.wiz_import_procurement_from_plan_view
 #: view:wiz.load.purchase.from.plan:procurement_plan.wiz_load_purchase_from_plan_view
 #: view:wiz.load.sale.from.plan:procurement_plan.wiz_load_sale_from_plan_view
@@ -35,12 +36,18 @@ msgid "Category"
 msgstr ""
 
 #. module: procurement_plan
+#: model:ir.actions.act_window,name:procurement_plan.action_change_procurement_scheduled_date
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid "Change scheduled date"
+msgstr ""
+
+#. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
 msgid "Check Procurements"
 msgstr ""
 
 #. module: procurement_plan
-#: field:procurement.plan,create_uid:0
+#: field:wiz.change.procurement.date,create_uid:0
 #: field:wiz.import.procurement.from.plan,create_uid:0
 #: field:wiz.load.purchase.from.plan,create_uid:0
 #: field:wiz.load.sale.from.plan,create_uid:0
@@ -48,7 +55,7 @@ msgid "Created by"
 msgstr ""
 
 #. module: procurement_plan
-#: field:procurement.plan,create_date:0
+#: field:wiz.change.procurement.date,create_date:0
 #: field:wiz.import.procurement.from.plan,create_date:0
 #: field:wiz.load.purchase.from.plan,create_date:0
 #: field:wiz.load.sale.from.plan,create_date:0
@@ -100,6 +107,12 @@ msgid "Error!: End date is lower than start date."
 msgstr ""
 
 #. module: procurement_plan
+#: code:addons/procurement_plan/wizard/wiz_change_procurement_date.py:43
+#, python-format
+msgid "Error!: No procurements found to treat."
+msgstr ""
+
+#. module: procurement_plan
 #: code:addons/procurement_plan/models/procurement_plan.py:81
 #: code:addons/procurement_plan/models/procurement_plan.py:106
 #, python-format
@@ -141,7 +154,7 @@ msgid "Holds the Chatter summary (number of messages, ...). This summary is dire
 msgstr ""
 
 #. module: procurement_plan
-#: field:procurement.plan,id:0
+#: field:wiz.change.procurement.date,id:0
 #: field:wiz.import.procurement.from.plan,id:0
 #: field:wiz.load.purchase.from.plan,id:0
 #: field:wiz.load.sale.from.plan,id:0
@@ -179,7 +192,7 @@ msgid "Last Message Date"
 msgstr ""
 
 #. module: procurement_plan
-#: field:procurement.plan,write_uid:0
+#: field:wiz.change.procurement.date,write_uid:0
 #: field:wiz.import.procurement.from.plan,write_uid:0
 #: field:wiz.load.purchase.from.plan,write_uid:0
 #: field:wiz.load.sale.from.plan,write_uid:0
@@ -187,7 +200,7 @@ msgid "Last Updated by"
 msgstr ""
 
 #. module: procurement_plan
-#: field:procurement.plan,write_date:0
+#: field:wiz.change.procurement.date,write_date:0
 #: field:wiz.import.procurement.from.plan,write_date:0
 #: field:wiz.load.purchase.from.plan,write_date:0
 #: field:wiz.load.sale.from.plan,write_date:0
@@ -235,6 +248,16 @@ msgstr ""
 #. module: procurement_plan
 #: help:procurement.plan,message_ids:0
 msgid "Messages and communication history"
+msgstr ""
+
+#. module: procurement_plan
+#: field:wiz.change.procurement.date,new_scheduled_date:0
+msgid "New scheduled date"
+msgstr ""
+
+#. module: procurement_plan
+#: field:wiz.change.procurement.date,old_scheduled_date:0
+msgid "Old scheduled date"
 msgstr ""
 
 #. module: procurement_plan
@@ -287,9 +310,22 @@ msgid "Procurements Plans"
 msgstr ""
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+#: field:wiz.change.procurement.date,procurements:0
+msgid "Procurements to treat"
+msgstr ""
+
+#. module: procurement_plan
 #: field:wiz.load.purchase.from.plan,product_id:0
 #: field:wiz.load.sale.from.plan,product_id:0
 msgid "Product"
+msgstr ""
+
+#. module: procurement_plan
+#: code:addons/procurement_plan/wizard/wiz_load_purchase_from_plan.py:102
+#: code:addons/procurement_plan/wizard/wiz_load_sale_from_plan.py:104
+#, python-format
+msgid "Product UOM or Product UOS not found for product: %s"
 msgstr ""
 
 #. module: procurement_plan
@@ -307,6 +343,11 @@ msgstr ""
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
 #: field:procurement.plan,purchase_ids:0
 msgid "Purchase Orders"
+msgstr ""
+
+#. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid "Put a new scheduled date in procurements"
 msgstr ""
 
 #. module: procurement_plan
@@ -377,6 +418,11 @@ msgid "Template"
 msgstr ""
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
+msgid "They treated procurements of type INTERNAL, without purchases, or with purchases with state DRAFT."
+msgstr ""
+
+#. module: procurement_plan
 #: view:procurement.plan:procurement_plan.procurement_plan_form_view
 msgid "Unit of Measure"
 msgstr ""
@@ -423,6 +469,7 @@ msgid "name"
 msgstr ""
 
 #. module: procurement_plan
+#: view:wiz.change.procurement.date:procurement_plan.wiz_change_procurement_date_view
 #: view:wiz.import.procurement.from.plan:procurement_plan.wiz_import_procurement_from_plan_view
 #: view:wiz.load.purchase.from.plan:procurement_plan.wiz_load_purchase_from_plan_view
 #: view:wiz.load.sale.from.plan:procurement_plan.wiz_load_sale_from_plan_view

--- a/procurement_plan/wizard/__init__.py
+++ b/procurement_plan/wizard/__init__.py
@@ -5,3 +5,4 @@
 from . import wiz_import_procurement_from_plan
 from . import wiz_load_sale_from_plan
 from . import wiz_load_purchase_from_plan
+from . import wiz_change_procurement_date

--- a/procurement_plan/wizard/wiz_change_procurement_date.py
+++ b/procurement_plan/wizard/wiz_change_procurement_date.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields, api, exceptions, _
+
+
+class WizChangeProcurementDate(models.TransientModel):
+    _name = 'wiz.change.procurement.date'
+
+    old_scheduled_date = fields.Datetime('Old scheduled date', readonly=True)
+    new_scheduled_date = fields.Datetime('New scheduled date', required=True)
+    procurements = fields.Many2many(
+        comodel_name='procurement.order', string='Procurements to treat',
+        relation='rel_wiz_change_procurement_date',
+        column1='wiz_change_procurement_date_id', column2='procurement_id',
+        readonly=True)
+
+    @api.model
+    def default_get(self, var_fields):
+        vals = {}
+        procurements = self._take_procurements_to_treat(
+            self.env.context['active_ids'])
+        if len(procurements) == 1:
+            vals['old_scheduled_date'] = procurements[0].date_planned
+        vals['procurements'] = [(6, 0, procurements.ids)]
+        return vals
+
+    def _take_procurements_to_treat(self, procurement_ids):
+        procurements = self.env['procurement.order'].browse(procurement_ids)
+        procurements = procurements.filtered(
+            lambda x: x.location_type == 'internal')
+        procurements = procurements.filtered(
+            lambda x: not x.purchase_line_id or (
+                x.purchase_line_id and x.purchase_line_id.order_id.state ==
+                'draft'))
+        return procurements
+
+    @api.multi
+    def change_scheduled_date(self):
+        if not self.procurements:
+            raise exceptions.Warning(
+                _('Error!: No procurements found to treat.'))
+        self._treat_procurements()
+
+    def _treat_procurements(self):
+        self._modify_procurements_for_po(self.procurements)
+
+    def _modify_procurements_for_po(self, procurements):
+        procurements.write({'date_planned': self.new_scheduled_date})
+        procurements = procurements.filtered(
+            lambda x: x.purchase_line_id and
+            x.purchase_line_id.order_id.state == 'draft')
+        purchase_order_lines = self.env['purchase.order.line']
+        purchase_order_lines |= procurements.mapped('purchase_line_id')
+        purchase_order_lines.write({'date_planned': self.new_scheduled_date})

--- a/procurement_plan/wizard/wiz_change_procurement_date_view.xml
+++ b/procurement_plan/wizard/wiz_change_procurement_date_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_change_procurement_date_view">
+            <field name="name">wiz.change.procurement.date.view</field>
+            <field name="model">wiz.change.procurement.date</field>
+            <field name="arch" type="xml">
+                <form string="Put a new scheduled date in procurements">
+                    <group>
+                        <label string="They treated procurements of type INTERNAL, without purchases, or with purchases with state DRAFT."/>
+                    </group>
+                    <group colspan="4" col="4">
+                        <field name="old_scheduled_date" />
+                        <field name="new_scheduled_date" />
+                    </group>
+                    <group colspan="4">
+                        <separator string="Procurements to treat" colspan="4"/>
+                        <field name="procurements" nolabel="1" colspan="4"/>
+                    </group>
+                    <footer>
+                        <button name="change_scheduled_date" type="object" 
+                                string="Change scheduled date" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link"
+                                special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+        <act_window name="Change scheduled date"
+                res_model="wiz.change.procurement.date"
+                src_model="procurement.order"
+                view_mode="form"
+                target="new"
+                key2="client_action_multi"
+                id="action_change_procurement_scheduled_date"/>
+    </data>
+</openerp>

--- a/procurement_plan_mrp/__openerp__.py
+++ b/procurement_plan_mrp/__openerp__.py
@@ -31,7 +31,8 @@
                 'stock_reserve',
                 'sale_mrp_project_link'
                 ],
-    "data": ['views/mrp_production_view.xml',
+    "data": ['wizard/wiz_change_procurement_date_planned_view.xml',
+             'views/mrp_production_view.xml',
              'views/procurement_plan_view.xml',
              'views/procurement_order_view.xml',
              'views/stock_reservation_view.xml',

--- a/procurement_plan_mrp/i18n/es.po
+++ b/procurement_plan_mrp/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-07 09:06+0000\n"
-"PO-Revision-Date: 2015-10-07 11:07+0100\n"
+"POT-Creation-Date: 2015-11-02 15:30+0000\n"
+"PO-Revision-Date: 2015-11-02 16:37+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,9 +23,35 @@ msgid "BoM not found, for product: %s"
 msgstr "LdM no encontrada, para el producto: %s"
 
 #. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: procurement_plan_mrp
+#: model:ir.actions.act_window,name:procurement_plan_mrp.act_change_date_planned
+#: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
+msgid "Change date planned"
+msgstr "Cambiar fecha planificada"
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Change scheduled date"
+msgstr "Cambiar fecha planificada"
+
+#. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Create lower levels"
 msgstr "Crear niveles inferiores"
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,create_date:0
+msgid "Created on"
+msgstr "Creado el"
 
 #. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
@@ -44,14 +70,35 @@ msgid "Generated from sale order: "
 msgstr "Generado desde el pedido de venta: "
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Import Procurements"
 msgstr "Importar abastecimientos"
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,write_uid:0
+msgid "Last Updated by"
+msgstr "Últim actualización por"
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: procurement_plan_mrp
 #: field:procurement.order,level:0
 msgid "Level"
 msgstr "Nivel"
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:21
+#, python-format
+msgid "Location of procurement order is not of type INTERNAL"
+msgstr "La ubicación del abastecimiento no es de tipo INTERNO"
 
 #. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
@@ -64,6 +111,11 @@ msgid "Manufacturing Order"
 msgstr "Orden de fabricación"
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,new_scheduled_date:0
+msgid "New scheduled date"
+msgstr "Nueva fecha planificación"
+
+#. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:206
 #, python-format
 msgid ""
@@ -72,6 +124,11 @@ msgid ""
 msgstr ""
 "Producto no definido para línea de LdM con plantilla: %s, en la lista de "
 "materiales %s"
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,old_scheduled_date:0
+msgid "Old scheduled date"
+msgstr "Vieja fecha planificada"
 
 #. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
@@ -100,6 +157,18 @@ msgid "Procurement from plan"
 msgstr "Abastecimiento desde plan"
 
 #. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:24
+#, python-format
+msgid "Procurement order with production order in state: %s"
+msgstr "Abastecimiento con orden de fabricación en estado: %s"
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:29
+#, python-format
+msgid "Procurement order with purchase order in state: %s"
+msgstr "Abastecimiento con pedido de compra en estado: %s"
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 msgid "Product"
 msgstr "Producto"
@@ -121,6 +190,11 @@ msgid "Purchase Orders"
 msgstr "Pedido de compra"
 
 #. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Put a new scheduled date in procurement"
+msgstr "Poner una nueva fecha planificación en abastecimiento"
+
+#. module: procurement_plan_mrp
 #: model:ir.model,name:procurement_plan_mrp.model_sale_order
 msgid "Sales Order"
 msgstr "Pedido de venta"
@@ -140,3 +214,39 @@ msgstr "Reserva de existencias"
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
 msgstr "NO SE HAN GENERADO TODOS LOS ABASTECIMIENTOS"
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid ""
+"They treated procurements of type INTERNAL, without purchases, or with "
+"purchases with state DRAFT."
+msgstr ""
+"Se tratar abastecimientos de tipo INTERNO, sin compras, o con compras en "
+"estado BORRADOR"
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date.py:79
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:76
+#, python-format
+msgid ""
+"You can not change the date planned of procurement order: %s, because the "
+"production order: %s, not in draft status"
+msgstr ""
+"No puede cambiar la fecha de planificación del abastecimiento: %s, porque la "
+"órden de fabricación: %s, no esta en estado borrador"
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date.py:66
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:64
+#, python-format
+msgid ""
+"You can not change the date planned of procurement order: %s, because the "
+"purchase order: %s, not in draft status"
+msgstr ""
+"No puede cambiar la fecha de planificación del abastecimiento: %s, porque el "
+"pedido de compra: %s, no está en estado borrador"
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "or"
+msgstr "or"

--- a/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
+++ b/procurement_plan_mrp/i18n/procurement_plan_mrp.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-07 09:06+0000\n"
-"PO-Revision-Date: 2015-10-07 09:06+0000\n"
+"POT-Creation-Date: 2015-11-02 15:30+0000\n"
+"PO-Revision-Date: 2015-11-02 15:30+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,8 +22,34 @@ msgid "BoM not found, for product: %s"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Cancel"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: model:ir.actions.act_window,name:procurement_plan_mrp.act_change_date_planned
+#: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
+msgid "Change date planned"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Change scheduled date"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Create lower levels"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,create_date:0
+msgid "Created on"
 msgstr ""
 
 #. module: procurement_plan_mrp
@@ -43,13 +69,34 @@ msgid "Generated from sale order: "
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,id:0
+msgid "ID"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: view:procurement.plan:procurement_plan_mrp.procurement_plan_form_view_inh_mrpprocurementplan
 msgid "Import Procurements"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: field:procurement.order,level:0
 msgid "Level"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:21
+#, python-format
+msgid "Location of procurement order is not of type INTERNAL"
 msgstr ""
 
 #. module: procurement_plan_mrp
@@ -63,9 +110,19 @@ msgid "Manufacturing Order"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,new_scheduled_date:0
+msgid "New scheduled date"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: code:addons/procurement_plan_mrp/models/procurement.py:206
 #, python-format
 msgid "No product defined for BoM line with template: %s, on the list of materials %s"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: field:wiz.change.procurement.date.planned,old_scheduled_date:0
+msgid "Old scheduled date"
 msgstr ""
 
 #. module: procurement_plan_mrp
@@ -95,6 +152,18 @@ msgid "Procurement from plan"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:24
+#, python-format
+msgid "Procurement order with production order in state: %s"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:29
+#, python-format
+msgid "Procurement order with purchase order in state: %s"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: view:mrp.production:procurement_plan_mrp.view_mrp_production_filter_inh_mrpprocurementplan
 msgid "Product"
 msgstr ""
@@ -116,6 +185,11 @@ msgid "Purchase Orders"
 msgstr ""
 
 #. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "Put a new scheduled date in procurement"
+msgstr ""
+
+#. module: procurement_plan_mrp
 #: model:ir.model,name:procurement_plan_mrp.model_sale_order
 msgid "Sales Order"
 msgstr ""
@@ -134,5 +208,29 @@ msgstr ""
 #: code:addons/procurement_plan_mrp/models/procurement.py:176
 #, python-format
 msgid "THEY HAVE NOT GENERATED ALL PROCUREMENTS"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "They treated procurements of type INTERNAL, without purchases, or with purchases with state DRAFT."
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date.py:79
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:76
+#, python-format
+msgid "You can not change the date planned of procurement order: %s, because the production order: %s, not in draft status"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date.py:66
+#: code:addons/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py:64
+#, python-format
+msgid "You can not change the date planned of procurement order: %s, because the purchase order: %s, not in draft status"
+msgstr ""
+
+#. module: procurement_plan_mrp
+#: view:wiz.change.procurement.date.planned:procurement_plan_mrp.wiz_change_procurement_date_planned_view
+msgid "or"
 msgstr ""
 

--- a/procurement_plan_mrp/models/sale_order.py
+++ b/procurement_plan_mrp/models/sale_order.py
@@ -32,7 +32,7 @@ class SaleOrderLine(models.Model):
                     ('group_id', '=', procurement.group_id.id),
                     ('product_id', '=', procurement.product_id.id),
                     ('product_qty', '=', self.product_uom_qty),
-                    ('production_id', '!=', False),
+#                    ('production_id', '!=', False),
                     ('plan', '=', False),
                     ('level', '=', 0)]
             procurement = proc_obj.search(cond, limit=1)

--- a/procurement_plan_mrp/views/procurement_plan_view.xml
+++ b/procurement_plan_mrp/views/procurement_plan_view.xml
@@ -24,6 +24,7 @@
                             attrs="{'invisible':[('show_button_delete','=',False)]}" />
                     <button name="button_create_lower_levels" type="object" string="Create lower levels" icon="gtk-convert"
                             attrs="{'invisible':[('show_button_create','=',False)]}" />
+                    <button name="%(act_change_date_planned)d" type="action" string="Change date planned" icon="terp-gtk-jump-to-ltr" />
                 </button>
             </field>
         </record>

--- a/procurement_plan_mrp/wizard/__init__.py
+++ b/procurement_plan_mrp/wizard/__init__.py
@@ -3,3 +3,5 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from . import wiz_import_procurement_from_plan
+from . import wiz_change_procurement_date
+from . import wiz_change_procurement_date_planned

--- a/procurement_plan_mrp/wizard/wiz_change_procurement_date.py
+++ b/procurement_plan_mrp/wizard/wiz_change_procurement_date.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields, exceptions, _
+from dateutil.relativedelta import relativedelta
+
+
+class WizChangeProcurementDate(models.TransientModel):
+    _inherit = 'wiz.change.procurement.date'
+
+    def _take_procurements_to_treat(self, procurement_ids):
+        procs = super(WizChangeProcurementDate,
+                      self)._take_procurements_to_treat(procurement_ids)
+        procs = procs.filtered(lambda x: x.level == 0)
+        procs = procs.filtered(lambda x: not x.production_id or (
+            x.production_id and x.production_id.state == 'draft'))
+        return procs
+
+    def _treat_procurements(self):
+        super(WizChangeProcurementDate, self)._treat_procurements()
+        route_id = self.env.ref('mrp.route_warehouse0_manufacture').id,
+        procurements = self.procurements.filtered(
+            lambda x: route_id[0] in x.product_id.route_ids.ids)
+        self._treat_procurements_for_mo(procurements)
+
+    def _modify_procurements_for_po(self, procurements):
+        route_id = self.env.ref('mrp.route_warehouse0_manufacture').id,
+        procurements = procurements.filtered(
+            lambda x: route_id[0] not in x.product_id.route_ids.ids)
+        super(WizChangeProcurementDate, self)._modify_procurements_for_po(
+            procurements)
+
+    def _treat_procurements_for_mo(self, procurements):
+        for procurement in procurements:
+            if procurement.date_planned > self.new_scheduled_date:
+                timedelta = (fields.Datetime.from_string(
+                    procurement.date_planned) - fields.Datetime.from_string(
+                    self.new_scheduled_date)) * -1
+            else:
+                timedelta = fields.Datetime.from_string(
+                    self.new_scheduled_date) - fields.Datetime.from_string(
+                    procurement.date_planned)
+            procurement.write({'date_planned': self.new_scheduled_date})
+            if (procurement.production_id and
+                    procurement.production_id.state == 'draft'):
+                procurement.production_id.write(
+                    {'date_planned': self.new_scheduled_date})
+            if procurement.plan:
+                self._treat_procurements_childrens(procurement, timedelta.days)
+
+    def _treat_procurements_childrens(self, procurement, days_to_sum):
+        route_id = self.env.ref('mrp.route_warehouse0_manufacture').id
+        proc_obj = self.env['procurement.order']
+        cond = [('parent_procurement_id', 'child_of', procurement.id),
+                ('id', '!=', procurement.id)]
+        procs = proc_obj.search(cond)
+        for proc in procs:
+            new_date = (fields.Datetime.from_string(proc.date_planned) +
+                        (relativedelta(days=days_to_sum)))
+            proc.write({'date_planned': new_date})
+            if route_id not in proc.product_id.route_ids.ids:
+                if proc.purchase_line_id:
+                    if proc.purchase_line_id.order_id.state != 'draft':
+                        raise exceptions.Warning(
+                            _('You can not change the date planned of'
+                              ' procurement order: %s, because the purchase'
+                              ' order: %s, not in draft status') %
+                            (proc.name, proc.purchase_line_id.order_id.name))
+                    else:
+                        new_date = (fields.Datetime.from_string(
+                                    proc.purchase_line_id.date_planned) +
+                                    (relativedelta(days=days_to_sum)))
+                        proc.purchase_line_id.write({'date_planned': new_date})
+            else:
+                if proc.production_id:
+                    if proc.production_id.state != 'draft':
+                        raise exceptions.Warning(
+                            _('You can not change the date planned of'
+                              ' procurement order: %s, because the production'
+                              ' order: %s, not in draft status') %
+                            (proc.name, proc.production_id.name))
+                    else:
+                        new_date = (fields.Datetime.from_string(
+                                    proc.production_id.date_planned) +
+                                    (relativedelta(days=days_to_sum)))
+                        proc.production_id.write({'date_planned': new_date})

--- a/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py
+++ b/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, fields, api, exceptions, _
+from dateutil.relativedelta import relativedelta
+
+
+class WizChangeProcurementDatePlanned(models.TransientModel):
+    _name = 'wiz.change.procurement.date.planned'
+
+    old_scheduled_date = fields.Datetime('Old scheduled date', readonly=True)
+    new_scheduled_date = fields.Datetime('New scheduled date', required=True)
+
+    @api.model
+    def default_get(self, var_fields):
+        vals = {}
+        proc = self.env['procurement.order'].browse(self._context['active_id'])
+        if proc.location_type != 'internal':
+            raise exceptions.Warning(
+                _('Location of procurement order is not of type INTERNAL'))
+        if proc.production_id and proc.production_id.state != 'draft':
+            raise exceptions.Warning(
+                _('Procurement order with production order in state: %s') %
+                (proc.production_id.state))
+        if (proc.purchase_line_id and proc.purchase_line_id.order_id.state !=
+                'draft'):
+            raise exceptions.Warning(
+                _('Procurement order with purchase order in state: %s') %
+                (proc.production_id.state))
+        vals['old_scheduled_date'] = proc.date_planned
+        return vals
+
+    @api.multi
+    def change_scheduled_date(self):
+        proc_obj = self.env['procurement.order']
+        procu = proc_obj.browse(self._context['active_id'])
+        if procu.date_planned > self.new_scheduled_date:
+            days_to_sum = (fields.Datetime.from_string(
+                procu.date_planned) - fields.Datetime.from_string(
+                self.new_scheduled_date)) * -1
+        else:
+            days_to_sum = fields.Datetime.from_string(
+                self.new_scheduled_date) - fields.Datetime.from_string(
+                procu.date_planned)
+        procu.write({'date_planned': self.new_scheduled_date})
+        if procu.production_id and procu.production_id.state == 'draft':
+            procu.production_id.write({'date_planned':
+                                       self.new_scheduled_date})
+        if (procu.purchase_line_id and procu.purchase_line_id.order_id.state !=
+                'draft'):
+            procu.purchase_line_id.write({'date_planned':
+                                          self.new_scheduled_date})
+        cond = [('parent_procurement_id', 'child_of', procu.id),
+                ('id', '!=', procu.id)]
+        procs = proc_obj.search(cond)
+        for proc in procs:
+            new_date = (fields.Datetime.from_string(proc.date_planned) +
+                        (relativedelta(days=days_to_sum.days)))
+            proc.write({'date_planned': new_date})
+            if proc.purchase_line_id:
+                if proc.purchase_line_id.order_id.state != 'draft':
+                    raise exceptions.Warning(
+                        _('You can not change the date planned of'
+                          ' procurement order: %s, because the purchase'
+                          ' order: %s, not in draft status') %
+                        (proc.name, proc.purchase_line_id.order_id.name))
+                else:
+                    new_date = (fields.Datetime.from_string(
+                                proc.purchase_line_id.date_planned) +
+                                (relativedelta(days=days_to_sum)))
+                    proc.purchase_line_id.write({'date_planned': new_date})
+            if proc.production_id:
+                if proc.production_id.state != 'draft':
+                    raise exceptions.Warning(
+                        _('You can not change the date planned of'
+                          ' procurement order: %s, because the production'
+                          ' order: %s, not in draft status') %
+                        (proc.name, proc.production_id.name))
+                else:
+                    new_date = (fields.Datetime.from_string(
+                                proc.production_id.date_planned) +
+                                (relativedelta(days=days_to_sum)))
+                    proc.production_id.write({'date_planned': new_date})
+        res = {'view_type': 'form,tree',
+               'res_model': 'procurement.plan',
+               'view_id': False,
+               'type': 'ir.actions.act_window',
+               'view_mode': 'form',
+               'res_id': procu.plan.id,
+               'target': 'current'
+               }
+        return res

--- a/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned_view.xml
+++ b/procurement_plan_mrp/wizard/wiz_change_procurement_date_planned_view.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_change_procurement_date_planned_view">
+            <field name="name">wiz.change.procurement.date.planned.view</field>
+            <field name="model">wiz.change.procurement.date.planned</field>
+            <field name="arch" type="xml">
+                <form string="Put a new scheduled date in procurement">
+                    <group>
+                        <label string="They treated procurements of type INTERNAL, without purchases, or with purchases with state DRAFT."/>
+                    </group>
+                    <group colspan="4" col="4">
+                        <field name="old_scheduled_date" />
+                        <field name="new_scheduled_date" />
+                    </group>
+                    <footer>
+                        <button name="change_scheduled_date" type="object" 
+                                string="Change scheduled date" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link"
+                                special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+        <record id="act_change_date_planned" model="ir.actions.act_window">
+            <field name="name">Change date planned</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wiz.change.procurement.date.planned</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="wiz_change_procurement_date_planned_view"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
[IMP] procurement_plan_mrp: wizard for change procurement date_planned.

Se han modificado los módulos "procurement_plan", y "procurement_plan_mrp" para poder modificar la fecha de planificación de los abastecimientos, y de sus hijos en caso de que los tenga. Los pedidos de compra, y la OF asignados a estos, deberán de estar en estado borrador, para poder modificar dicha fecha.
