### PR TITLE
[IMP] mrp_lot_reserve: checking lot availability before confirming removed

### DIFF
--- a/mrp_lot_reserve/README.rst
+++ b/mrp_lot_reserve/README.rst
@@ -1,7 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
-mrp_lot_reserve
-===========
+===============
+MRP Lot Reserve
+===============
+
 This module allows to fix a lot/serial number for the scheduled products
 (raw materials to consume) of a manufacturing order, so that this lot will be
 used (if available) when consuming this product.
-If the lot is not available a warning will be raised.
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/188/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/odoomrp/odoomrp-wip/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback `here <https://github.com/odoomrp/odoomrp-wip/issues/new?body=module:%20mrp_lot_reserve%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Daniel Campos <danielcampos@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>

--- a/mrp_lot_reserve/__init__.py
+++ b/mrp_lot_reserve/__init__.py
@@ -1,20 +1,5 @@
-
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# (c) 2015 Daniel Campos - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models

--- a/mrp_lot_reserve/__openerp__.py
+++ b/mrp_lot_reserve/__openerp__.py
@@ -1,33 +1,27 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Daniel Campos - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
-##############################################################################
 {
-    'name': 'MRP Lot Reserve',
-    'version': "1.0",
+    "name": "MRP Lot Reserve",
+    "version": "8.0.1.0.0",
     "category": "Manufacturing",
-    "author": "OdooMRP team,"
-              "AvanzOSC,"
+    "license": "AGPL-3",
+    "author": "OdooMRP team, "
+              "AvanzOSC, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
-    'contributors': ["Daniel Campos <danielcampos@avanzosc.es>",
-                     "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
-                     "Ana Juaristi <ajuaristio@gmail.com>"],
-    'website': "http://www.odoomrp.com",
-    'depends': ["mrp_production_editable_scheduled_products"],
-    'data': ["views/mrp_production_view.xml"],
-    'installable': True,
+    "website": "http://www.odoomrp.com",
+    "contributors": [
+        "Daniel Campos <danielcampos@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+    ],
+    "depends": [
+        "mrp_production_editable_scheduled_products",
+    ],
+    "data": [
+        "views/mrp_production_view.xml",
+    ],
+    "installable": True,
 }

--- a/mrp_lot_reserve/models/__init__.py
+++ b/mrp_lot_reserve/models/__init__.py
@@ -1,20 +1,5 @@
-
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# (c) 2015 Daniel Campos - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import mrp_production

--- a/mrp_lot_reserve/models/mrp_production.py
+++ b/mrp_lot_reserve/models/mrp_production.py
@@ -1,23 +1,8 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Daniel Campos - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
-##############################################################################
-
-from openerp import models, fields, api, exceptions, _
+from openerp import api, fields, models
 
 
 class MrpProduction(models.Model):
@@ -39,29 +24,16 @@ class MrpProduction(models.Model):
         @param location_id: Location id to check
         @param quantity: Quantity expected
         """
-        quant_obj = self.env['stock.quant']
-        aval_quant_lst = quant_obj.search([('lot_id', '=', lot_id),
-                                           ('location_id', '=', location_id)])
-        if aval_quant_lst:
-            available_qty = sum([x.qty for x in aval_quant_lst])
-            if available_qty >= quantity:
-                return True
+        company = self.company_id or self.env.user.company_id
+        if not company.reserve_lot:
+            return True
+        aval_quant_lst = self.env['stock.quant'].search([
+            ('lot_id', '=', lot_id),
+            ('location_id', '=', location_id)
+        ])
+        if aval_quant_lst and sum(aval_quant_lst.mapped('qty')) >= quantity:
+            return True
         return False
-
-    @api.multi
-    def action_confirm(self):
-        for line in self.product_lines:
-            if line.lot:
-                available = self._check_lot_quantity(line.lot.id,
-                                                     self.location_src_id.id,
-                                                     line.product_qty)
-                if not available:
-                    raise exceptions.Warning(
-                        _('No Lot Available'),
-                        _('There is no lot %s available for product: %s') %
-                        (line.lot.name, line.name))
-        res = super(MrpProduction, self).action_confirm()
-        return res
 
 
 class MrpProductionProductLine(models.Model):


### PR DESCRIPTION
Now it will allow to confirm a MO if there is no enough qty in lot,
so that it will pick the lot first and then it will take from other lots
