### PR TITLE
[FIX] mrp_product_variants: not passing production by context

### DIFF
--- a/mrp_product_variants/models/mrp_production.py
+++ b/mrp_product_variants/models/mrp_production.py
@@ -185,9 +185,10 @@ class MrpProduction(models.Model):
                                           production.product_qty,
                                           bom_point.product_uom.id)
             # product_lines, workcenter_lines
-            results, results2 = bom_point._bom_explode(
-                production.product_id, factor / bom_point.product_qty,
-                properties, routing_id=production.routing_id.id)
+            results, results2 = bom_point.with_context(
+                production=production)._bom_explode(
+                    production.product_id, factor / bom_point.product_qty,
+                    properties, routing_id=production.routing_id.id)
             #  reset product_lines in production order
             for line in results:
                 line['production_id'] = production.id


### PR DESCRIPTION
As commented in https://github.com/odoomrp/odoomrp-wip/commit/32916e6e7fd6669566c9ee21cfee54eb219f454b#commitcomment-14418274

@zamberjo @pedrobaeza will it be correct now?
