### PR TITLE
[FIX] mrp_production_simulated_capacity: case not taken into account.

### DIFF
--- a/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
+++ b/mrp_production_project_estimated_cost/wizard/wiz_create_fictitious_of.py
@@ -45,11 +45,13 @@ class WizCreateFictitiousOf(models.TransientModel):
             if 'routing_id' in vals:
                 routing = routing_obj.browse(vals['routing_id'])
                 product_qty = production_obj._get_min_qty_for_production(
-                    routing)
+                    routing) or 1
                 vals['product_qty'] = product_qty
                 prod_vals = production_obj.product_id_change(
                     product.id, product_qty)['value']
                 vals.update(prod_vals)
+            vals['product_attributes'] = [tuple([0, 0, line]) for line in
+                vals.get('product_attributes', [])]
             new_production = production_obj.create(vals)
             new_production.action_compute()
             new_production.calculate_production_estimated_cost()

--- a/mrp_production_simulated_capacity/models/mrp_production.py
+++ b/mrp_production_simulated_capacity/models/mrp_production.py
@@ -27,7 +27,6 @@ class MrpProduction(models.Model):
     def _get_min_qty_for_production(self, routing=False):
         qty = super(MrpProduction, self)._get_min_qty_for_production(routing)
         min_capacity = routing and max(routing.workcenter_lines.filtered(
-            'limited_production_capacity').mapped('workcenter_id.'
-                                                  'capacity_per_cycle_min')
-            ) or 0
+            'limited_production_capacity').mapped(
+                'workcenter_id.capacity_per_cycle_min') or [0]) or 0
         return max(qty, min_capacity)


### PR DESCRIPTION
[FIX] mrp_production_simulated_capacity: Raises an error when there's no workcenter which limits order's quantity.
[FIX] mrp_production_production_project_estimated_cost: convert attribute lines for the creation of a MO.
