### PR TITLE
[FIX] stock_inventory_import: in some cases failed lines are not processed

### DIFF
--- a/stock_inventory_import/models/stock_inventory.py
+++ b/stock_inventory_import/models/stock_inventory.py
@@ -54,7 +54,7 @@ class StockInventory(models.Model):
                         product = prod_lst[0]
                     else:
                         line.fail_reason = _('No product code found')
-                    continue
+                        continue
                 else:
                     product = line.product
                 lot_id = None


### PR DESCRIPTION
In some cases failed lines are not processed in stock.inventory process_import_lines method due to 'continue' bad placement.
