### PR TITLE
[REF] product_variant_default_code: Modular programming on method render_default_code

### DIFF
--- a/product_variant_default_code/models/product.py
+++ b/product_variant_default_code/models/product.py
@@ -49,7 +49,7 @@ def sanitize_reference_mask(product, mask):
                                        '"Variant Reference Mask"'))
 
 
-def render_default_code(product, mask):
+def get_rendered_default_code(product, mask):
     product_attrs = defaultdict(str)
     reference_mask = ReferenceMask(mask)
     for value in product.attribute_value_ids:
@@ -60,7 +60,11 @@ def render_default_code(product, mask):
     missing = dict.fromkeys(missing_attrs, PLACE_HOLDER_4_MISSING_VALUE)
     product_attrs.update(missing)
     default_code = reference_mask.safe_substitute(product_attrs)
-    product.default_code = default_code
+    return default_code
+
+
+def render_default_code(product, mask):
+    product.default_code = get_rendered_default_code(product, mask)
 
 
 class ProductTemplate(models.Model):


### PR DESCRIPTION
Separate the default code assignment in 2 steps, one obtains the
code and the other set this value on product.
Now is easier to extend this method.
