### PR TITLE
fix cycle calculation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,6 @@ coverage.xml
 # Pycharm
 .idea
 
-# Eclipse
-.settings/
-
 # Mr Developer
 .mr.developer.cfg
 .project
@@ -57,3 +54,6 @@ docs/_build/
 # Backup files
 *~
 *.swp
+
+# OSX Files
+*.DS_Store

--- a/mrp_product_variants_operations/models/mrp_production.py
+++ b/mrp_product_variants_operations/models/mrp_production.py
@@ -38,7 +38,7 @@ class MrpProduction(models.Model):
         for workorder in workcenter_lines:
             wc = workorder.routing_wc_line
             cycle = wc.cycle_nbr and int(math.ceil(self.product_qty /
-                                                   (wc.cycle_nbr * self.bom_id.product_qty))) or 0
+                (wc.cycle_nbr * self.bom_id.product_qty))) or 0
             workorder.cycle = cycle
             workorder.hour = wc.hour_nbr * cycle
         for p_line in product_lines:

--- a/mrp_product_variants_operations/models/mrp_production.py
+++ b/mrp_product_variants_operations/models/mrp_production.py
@@ -38,7 +38,7 @@ class MrpProduction(models.Model):
         for workorder in workcenter_lines:
             wc = workorder.routing_wc_line
             cycle = wc.cycle_nbr and int(math.ceil(self.product_qty /
-                                                   wc.cycle_nbr)) or 0
+                                                   (wc.cycle_nbr * self.bom_id.product_qty))) or 0
             workorder.cycle = cycle
             workorder.hour = wc.hour_nbr * cycle
         for p_line in product_lines:


### PR DESCRIPTION
When cycles are calculated for a manufacturing order, you need to take into account the BoM’s product quantity so that the number of cycles is calculated accordingly, e.g. if you have a BoM crated on a basis of 100 kg of finished product, when you process a manufacturing order for 300 kg, the number of cycles calculated should be 3 instead of 300.
