### PR TITLE
[REM] mrp_subcontracting: Remove duplicated field 'picking_type_id'

### DIFF
--- a/mrp_subcontracting/views/mrp_routing_workcenter_view.xml
+++ b/mrp_subcontracting/views/mrp_routing_workcenter_view.xml
@@ -20,8 +20,6 @@
                     <field name="external"/>
                     <field name="semifinished_id"
                            attrs="{'invisible': [('external', '=', False)], 'required': [('external', '=', True)]}"/>
-                    <field name="picking_type_id"
-                           attrs="{'invisible': [('external', '=', False)], 'required': [('external', '=', True)]}"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Duplicated field on view mrp_routing_workcenter_tree_view when the database
have installed mrp_subcontracting and mrp_operations_extension modules.

See issue [#1107](https://github.com/odoomrp/odoomrp-wip/issues/1107)
