### PR TITLE
Revert "[ADD] Filter pricelist by currency"

### DIFF
--- a/sale_pricelist_rules/views/sale_view.xml
+++ b/sale_pricelist_rules/views/sale_view.xml
@@ -30,8 +30,7 @@
                     <xpath
                         expr="//field[@name='order_line']/form//field[@name='address_allotment_id']"
                         position="after">
-                        <field name="item_id" groups="product.group_sale_pricelist" widget="selection"
-                            domain="[('pricelist.currency_id', '=', parent.currency_id)]" />
+                        <field name="item_id" groups="product.group_sale_pricelist" widget="selection" />
                         <field name="possible_item_ids" invisible="1" />
                         <field name="offer_id"
                             groups="sale.group_discount_per_so_line" />


### PR DESCRIPTION
Reverts odoomrp/odoomrp-wip#1088

The domain set on view definition

> <field name="item_id" groups="product.group_sale_pricelist" widget="selection"
> domain="[('pricelist.currency_id', '=', parent.currency_id)]" />

strikes the domain created in the model file.

> res['domain'].update({'item_id':
>                                    [('id', 'in',
>                                      self._get_possible_item_ids(
>                                         pricelist, product_id=product,
>                                          qty=qty))]})

So PR which domain is added is incorrect.
