### PR TITLE
[FIX] adds sale and purchase description to name fields

### DIFF
--- a/purchase_product_variants/models/purchase_order.py
+++ b/purchase_product_variants/models/purchase_order.py
@@ -117,6 +117,8 @@ class PurchaseOrderLine(models.Model):
         self.ensure_one()
         res = {}
         self.name = self.product_template.name
+        if self.product_template.description_purchase:
+            self.name += '\n' + self.product_template.description_purchase
         if not self.product_template.attribute_line_ids:
             self.product_id = self.product_template.product_variant_ids[:1]
         else:
@@ -189,6 +191,9 @@ class PurchaseOrderLine(models.Model):
             self.name = self._get_product_description(
                 self.product_template, False,
                 self.product_attributes.mapped('value'))
+            if self.product_template.description_purchase:
+                self.name += '\n' + self.product_template.description_purchase
+
 
     @api.multi
     def onchange_product_id(

--- a/purchase_product_variants/models/purchase_order.py
+++ b/purchase_product_variants/models/purchase_order.py
@@ -194,7 +194,6 @@ class PurchaseOrderLine(models.Model):
             if self.product_template.description_purchase:
                 self.name += '\n' + self.product_template.description_purchase
 
-
     @api.multi
     def onchange_product_id(
             self, pricelist_id, product_id, qty, uom_id, partner_id,

--- a/sale_product_variants/models/sale_order.py
+++ b/sale_product_variants/models/sale_order.py
@@ -133,6 +133,8 @@ class SaleOrderLine(models.Model):
                 product._get_product_attributes_values_dict())
             res['value']['name'] = self._get_product_description(
                 product.product_tmpl_id, product, product.attribute_value_ids)
+            if product.description_sale:
+                res['value']['name'] += '\n' + product.description_sale
         return res
 
     @api.multi
@@ -140,6 +142,8 @@ class SaleOrderLine(models.Model):
     def onchange_product_template(self):
         self.ensure_one()
         self.name = self.product_template.name
+        if self.product_template.description_sale:
+            self.name += '\n' + self.product_template.description_sale
         if not self.product_template.attribute_line_ids:
             self.product_id = (
                 self.product_template.product_variant_ids and


### PR DESCRIPTION
description_sale and description_purchase were left behind unused. this fix appends these fields to description of the product. (it works this way in standard)
