### PR TITLE
[IMP] mrp_repair_analytic: añadir costes en líneas

### DIFF
--- a/mrp_repair_analytic/tests/test_mrp_repair_analytic.py
+++ b/mrp_repair_analytic/tests/test_mrp_repair_analytic.py
@@ -13,6 +13,9 @@ class TestMrpRepairAnalytic(common.TransactionCase):
         self.mrp_repair_model = self.env['mrp.repair']
         self.analytic_account_model = self.env['account.analytic.account']
         self.analytic_line_model = self.env['account.analytic.line']
+        self.lot_model = self.env['stock.production.lot']
+        self.location_model = self.env['stock.location']
+        self.quant_model = self.env['stock.quant']
         analytic_vals = {
             'name': 'Repair Cost Account',
             'type': 'normal',
@@ -29,6 +32,19 @@ class TestMrpRepairAnalytic(common.TransactionCase):
             'type': 'add',
             'location_id': default_location,
             'location_dest_id': self.op_product.property_stock_production.id,
+            'price_unit': 1,
+            'to_invoice': True,
+            'load_cost': True,
+            }
+        self.op2_product = self.env.ref('product.product_product_35')
+        op_val2 = {
+            'product_id': self.op_product.id,
+            'product_uom_qty': 3,
+            'name': self.op2_product.name,
+            'product_uom': self.op2_product.uom_id.id,
+            'type': 'add',
+            'location_id': default_location,
+            'location_dest_id': self.op2_product.property_stock_production.id,
             'price_unit': 1,
             'to_invoice': True,
             'load_cost': True,
@@ -54,7 +70,7 @@ class TestMrpRepairAnalytic(common.TransactionCase):
             'partner_id': self.env.ref('base.res_partner_8').id,
             'location_id': default_location,
             'location_dest_id': default_location,
-            'operations': [(0, 0, op_val)],
+            'operations': [(0, 0, op_val), (0, 0, op_val2)],
             'fees_lines': [(0, 0, fee_val)],
             'invoice_method': 'after_repair',
             'partner_invoice_id': self.env.ref('base.res_partner_8').id
@@ -113,9 +129,13 @@ class TestMrpRepairAnalytic(common.TransactionCase):
         self.assertNotEqual(len(fee_line), 0, "Fee line cost not found.")
 
     def test_mrp_repair_cero_amount_cost(self):
+        self.op_product.cost_method = 'average'
+        self.op_product.standard_price = 0
+        for op in self.mrp_repair.operations:
+            if op.product_id == self.op_product:
+                op.product_uom_qty = 12
         self.mrp_repair.signal_workflow('repair_confirm')
         self.mrp_repair.create_repair_cost()
-        self.op_product.standard_price = 0
         ope_line = self.analytic_line_model.search(
             [('account_id', '=', self.analytic_id.id),
              ('product_id', '=', self.op_product.id),
@@ -161,3 +181,28 @@ class TestMrpRepairAnalytic(common.TransactionCase):
             self.assertEqual(
                 line.invoice_line_id.account_analytic_id, self.analytic_id,
                 "Wrong analytic account in the fee invoice line.")
+
+    def test_mrp_repair_line_cost(self):
+        self.op2_product.cost_method = 'real'
+        internal_location = self.location_model.search([('usage', '=',
+                                                         'internal')], limit=1)
+        lot_id = self.lot_model.create(
+            {'product_id': self.op2_product.id,
+             'name': 'LOT-TEST'})
+        self.quant_model.create(
+            {'product_id': self.op2_product.id,
+             'lot_id': lot_id.id,
+             'cost': 11,
+             'location_id': internal_location.id,
+             'qty': 5})
+        for operation in self.mrp_repair.operations:
+            cost = 0
+            if operation.product_id.cost_method == 'real' and operation.lot_id:
+                quants = operation.lot_id.quant_ids.filtered(
+                    lambda x: x.location_id.usage == 'internal')
+                if quants:
+                    cost = quants[:1].cost
+            else:
+                cost = operation.product_id.standard_price
+            self.assertEqual(operation.standard_price, cost,
+                             "Operation line cost is not correct.")

--- a/mrp_repair_analytic/views/mrp_repair_view.xml
+++ b/mrp_repair_analytic/views/mrp_repair_view.xml
@@ -22,21 +22,43 @@
                 <field name="partner_id" position="after">
                     <field name="analytic_account" />
                 </field>
-                <xpath expr="//form[@string='Fees']/group/group/field[@name='to_invoice']" position="before">
+                <xpath expr="//field[@name='fees_lines']/form//field[@name='to_invoice']" position="before">
                     <field name="load_cost" groups="mrp_repair_analytic.group_mrp_repair_cost_check"/>
                     <field name="user_id"/>
                 </xpath>
-                <xpath expr="//tree[@string='Fees']/field[@name='product_id']" position="before">
+                <xpath expr="//field[@name='fees_lines']/tree//field[@name='product_id']" position="before">
                     <field name="load_cost" groups="mrp_repair_analytic.group_mrp_repair_cost_check"/>
                     <field name="user_id"/>
                 </xpath>
-                <xpath expr="//page[@string='Repair Line']/group/field[@name='name']" position="before">
+                <xpath expr="//field[@name='operations']/form//field[@name='name']" position="before">
                     <field name="load_cost" groups="mrp_repair_analytic.group_mrp_repair_cost_check"/>
                     <field name="user_id"/>
                 </xpath>
-                <xpath expr="//tree[@string='Operations']/field[@name='type']" position="before">
+                <xpath expr="//field[@name='operations']/tree//field[@name='type']" position="before">
                     <field name="load_cost" groups="mrp_repair_analytic.group_mrp_repair_cost_check"/>
                     <field name="user_id"/>
+                </xpath>
+                <xpath expr="//field[@name='operations']/tree//field[@name='price_unit']" position="before">
+                    <field name="standard_price"/>
+                    <field name="cost_subtotal" sum="Operations cost subtotal"/>
+                </xpath>
+                <xpath expr="//field[@name='operations']/form//field[@name='price_unit']" position="before">
+                    <field name="standard_price"/>
+                    <field name="cost_subtotal"/>
+                </xpath>
+                <xpath expr="//field[@name='fees_lines']/tree//field[@name='price_unit']" position="before">
+                    <field name="standard_price"/>
+                    <field name="cost_subtotal" sum="Fees cost subtotal"/>
+                </xpath>
+                <xpath expr="//field[@name='fees_lines']/form//field[@name='price_unit']" position="before">
+                    <field name="standard_price"/>
+                    <field name="cost_subtotal"/>
+                </xpath>
+                <xpath expr="//field[@name='operations']/tree//field[@name='price_subtotal']" position="attributes">
+                    <attribute name="sum">Operations price subtotal</attribute>
+                </xpath>
+                <xpath expr="//field[@name='fees_lines']/tree//field[@name='price_subtotal']" position="attributes">
+                    <attribute name="sum">Fees price subtotal</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
He traído los campos cost_subtotal y el standard price de las líneas de reparación y de las fee lines desde el módulo `mrp_repair_fee`
Ya que en costes hay que cargar el coste adecuado. Y no tenía mucho sentido crear estos campos en aquel módulo.
