### PR TITLE
Update product_variant_default_code for odoo9

### DIFF
--- a/product_variant_default_code/__openerp__.py
+++ b/product_variant_default_code/__openerp__.py
@@ -32,5 +32,5 @@
     "data": ['views/product_attribute_value_view.xml',
              'views/product_view.xml',
              ],
-    'installable': False
+    'installable': True
 }

--- a/product_variant_default_code/views/product_attribute_value_view.xml
+++ b/product_variant_default_code/views/product_attribute_value_view.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0"?>
 <openerp>
     <data>
-        <record id="variants_template_tree_view_inh_variantdefaultcode" model="ir.ui.view">
-            <field name="name">variants.template.tree.view.inh.variantdefaultcode</field>
-            <field name="model">product.attribute.value</field>
-            <field name="inherit_id" ref="product.variants_template_tree_view"/>
-            <field name="arch" type="xml">
-                <field name="name" position="after">
-                    <field name="attribute_code" />
-                </field>
-            </field>
-        </record>
         <record id="variants_tree_view_inh_variantdefaultcode" model="ir.ui.view">
             <field name="name">variants.tree.view.inh.variantdefaultcode</field>
             <field name="model">product.attribute.value</field>


### PR DESCRIPTION
Remove product.variants_template_tree_view because it does not exist in odoo 9
