### PR TITLE
[FIX] mrp_packaging: not working properly if product.product is not d…

### DIFF
--- a/mrp_packaging/models/mrp_production.py
+++ b/mrp_packaging/models/mrp_production.py
@@ -85,13 +85,15 @@ class MrpProduction(models.Model):
     @api.one
     def recalculate_product_qty(self, qty, product):
         line = self.product_lines.filtered(
-            lambda x: x.product_id == product)
+            lambda x: x.product_id == product or
+            x.product_template == product.product_tmpl_id)
         line.write({'product_qty': qty})
 
     @api.one
     def assign_parent_lot(self, production):
         line = self.product_lines.filtered(
-            lambda x: x.product_id == production.product_id)
+            lambda x: x.product_id == production.product_id or
+            x.product_template == production.product_id.product_tmpl_id)
         line.write({'lot': (
                     production.move_created_ids2 and
                     production.move_created_ids2[0].restrict_lot_id.id or


### PR DESCRIPTION
…efined in BoM lines

Take into account that `mrp_product_variants` is a dependency of this module.
