### PR TITLE
[IMP] stock_picking_package_info, stock_picking_wave_package_info: transferir, forzar a crear operaciones

### DIFF
--- a/stock_picking_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_package_info/wizard/stock_transfer_details.py
@@ -13,7 +13,8 @@ class StockTransferDetails(models.TransientModel):
     def default_get(self, fields):
         picking = self.env['stock.picking'].browse(
             self.env.context.get('active_id'))
-        picking.create_all_move_packages()
+        if picking.pack_operation_ids:
+            picking.create_all_move_packages()
         return super(StockTransferDetails, self).default_get(fields)
 
     @api.multi

--- a/stock_picking_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_package_info/wizard/stock_transfer_details.py
@@ -9,13 +9,19 @@ from datetime import datetime
 class StockTransferDetails(models.TransientModel):
     _inherit = 'stock.transfer_details'
 
-    @api.one
+    @api.model
+    def default_get(self, fields):
+        picking = self.env['stock.picking'].browse(
+            self.env.context.get('active_id'))
+        picking.create_all_move_packages()
+        return super(StockTransferDetails, self).default_get(fields)
+
+    @api.multi
     def do_save_for_later(self):
+        self.ensure_one()
         operation_obj = self.env['stock.pack.operation'].with_context(
             no_recompute=True)
-        if not self.item_ids and not self.packop_ids:
-            self.picking_id.pack_operation_ids.unlink()
-            return True
+        self.picking_id.pack_operation_ids.unlink()
         # Create new and update existing pack operations
         for lstits in [self.item_ids, self.packop_ids]:
             for prod in lstits:

--- a/stock_picking_wave_package_info/wizard/stock_transfer_details.py
+++ b/stock_picking_wave_package_info/wizard/stock_transfer_details.py
@@ -14,6 +14,7 @@ class StockTransferDetails(models.TransientModel):
         operation_obj = self.env['stock.pack.operation']
         for picking in self.picking_ids:
             # Create new and update existing pack operations
+            picking.pack_operation_ids.unlink()
             for line in [self.item_ids.filtered(lambda x: x.picking_id.id ==
                                                 picking.id),
                          self.packop_ids.filtered(lambda x: x.picking_id.id ==


### PR DESCRIPTION
Algún cliente que otro ha reportado el siguiente problema:
- Cuando guardas para más tarde parte del albarán, este te genera una operación.
- Cuando vuelves a transferir, únicamente te muestra las operaciones asignadas al albarán, pero no el resto de movimientos.

Solución aplicada:
- Se fuerza a generar operaciones por todos los movimientos y cantidades restantes del albarán. Así al transferir, muestra todos, tanto guardados, como el resto de movimientos.
- Al guardar las operaciones para más tarde, elimina las operaciones del albarán, y solo fuerza a guardar aquellos que se mantienen en el asistente. Así no nos guarda las operaciones que se generan al cargar el asistente, los que son para mostrar todos los movimientos, no solo los que están guardados.

@anajuaristi ha dicho que quiere hacer pruebas funcionales antes de que se mergee este PR. Por lo que hasta que de OK funcional, no mergear por favor.
