### PR TITLE
[FIX] Values in product_id_change or sale.py break orders from website

### DIFF
--- a/sale_product_variants/models/sale_order.py
+++ b/sale_product_variants/models/sale_order.py
@@ -130,8 +130,9 @@ class SaleOrderLine(models.Model):
             fiscal_position=fiscal_position, flag=flag)
         if product:
             product = product_obj.browse(product)
-            res['value']['product_attributes'] = (
-                product._get_product_attributes_values_dict())
+            attr_values_dict = product._get_product_attributes_values_dict()
+            attr_values = [(0, 0, values) for values in attr_values_dict]
+            res['value']['product_attributes'] = attr_values
             res['value']['name'] = self._get_product_description(
                 product.product_tmpl_id, product, product.attribute_value_ids)
             if product.description_sale:


### PR DESCRIPTION
When ordering variants from the website the onchange values provided as a list of dictionaries return an error.

Not sure if this is the best fix concerning the entire scope of the project. I tried changing the values directly from product_variants_no_automatic_creation/models/product.py _get_product_attributes_values_dict but it seems that in other models such as purchase.py the write value are adapted as well and I did not go further.
