### PR TITLE
[FIX] product_variants_no_automatic_creation: _check_configuration_validity constraint

### DIFF
--- a/product_variants_no_automatic_creation/models/product_product.py
+++ b/product_variants_no_automatic_creation/models/product_product.py
@@ -81,7 +81,8 @@ class ProductProduct(models.Model):
         :raises: exceptions.ValidationError: If the check is not valid.
         """
         for product in self:
-            if bool(product.product_tmpl_id.attribute_line_ids -
+            if bool(product.product_tmpl_id.attribute_line_ids.mapped(
+                    'attribute_id') -
                     product.attribute_line_ids.mapped('attribute_id')):
                 raise exceptions.ValidationError(
                     _("You have to fill all the attributes values."))


### PR DESCRIPTION
There is a bug in _check_configuration_validity constraint in product_variants_no_automatic_creation.

This constraint is not correctly defined because is comparing product.attribute.line with product.attribute so when creating a new product with variants an exception is raised:

```

ValidateError
Error while validating constraint
ValueError
Mixing apples and oranges: product.attribute.line(219,) - product.attribute(1,)
```
