### PR TITLE
[IMP] mrp_project_link_mto: cambio de dependencia a los modulos de manufacture

### DIFF
--- a/mrp_project_link_mto/__openerp__.py
+++ b/mrp_project_link_mto/__openerp__.py
@@ -21,7 +21,7 @@
     "summary": "Link production with projects for MTO",
     "version": "8.0.1.0.0",
     "depends": [
-        "mrp_project_link",
+        "mrp_project",
     ],
     "author": "OdooMRP team,"
               "AvanzOSC,"


### PR DESCRIPTION
Comprobado el correcto funcionamiento del modulo con la dependencia a OCA. Incluso se han comprobado el funcionamiento de los módulos sale_mrp_project_link y purchase_mrp_project_link.
