### PR TITLE
[FIX] Error in the inheritance of the read function for product.produ…

### DIFF
--- a/product_price_history/models/product_product.py
+++ b/product_price_history/models/product_product.py
@@ -65,7 +65,7 @@ class ProductProduct(models.Model):
         return res
 
     @api.multi
-    def read(self, fields, load='_classic_read'):
+    def read(self, fields=None, load='_classic_read'):
         if fields:
             fields.append('id')
         results = super(ProductProduct, self).read(fields, load=load)

--- a/product_price_history/models/product_template.py
+++ b/product_price_history/models/product_template.py
@@ -33,7 +33,7 @@ class ProductTemplate(models.Model):
         return res
 
     @api.multi
-    def read(self, fields, load='_classic_read'):
+    def read(self, fields=None, load='_classic_read'):
         if fields:
             fields.append('id')
         results = super(ProductTemplate, self).read(fields, load=load)


### PR DESCRIPTION
In overwrited method `read` is omitted the default value by `fields` argument causing an error:

```
read() takes at least 2 arguments (1 given)
```
