### PR TITLE
[FIX] procurement_plan: Cancel project where cancel procurement plan,…

### DIFF
--- a/procurement_plan/models/procurement.py
+++ b/procurement_plan/models/procurement.py
@@ -34,7 +34,6 @@ class ProcurementOrder(models.Model):
     def create(self, data):
         if 'plan' in self.env.context and 'plan' not in data:
             data['plan'] = self.env.context.get('plan')
-        data['is_new'] = False
         procurement = super(ProcurementOrder, self).create(data)
         return procurement
 

--- a/procurement_plan/models/procurement_plan.py
+++ b/procurement_plan/models/procurement_plan.py
@@ -136,6 +136,8 @@ class ProcurementPlan(models.Model):
     @api.multi
     def button_cancel(self):
         for plan in self:
+            if plan.project_id:
+                plan.project_id.set_cancel()
             procurements = plan.procurement_ids.filtered(
                 lambda x: x.state in ('confirmed', 'exception', 'running'))
             procurements.with_context(plan=plan.id).cancel()


### PR DESCRIPTION
… and remove reference to the field "is_new" in object "procurement.order".

Módulo modificado para quitar la referencia al campo "is_new" de "procurement.order", y cancelar el proyecto cuando se cancela el plan de abastecimientos.
