### PR TITLE
[FIX] stock_inventory_import: Return in action_done

### DIFF
--- a/stock_inventory_import/models/stock_inventory.py
+++ b/stock_inventory_import/models/stock_inventory.py
@@ -83,4 +83,4 @@ class StockInventory(models.Model):
                 raise exceptions.Warning(
                     _("Loaded lines must be processed at least one time for "
                       "inventory : %s") % (inventory.name))
-            super(StockInventory, inventory).action_done()
+        return super(StockInventory, self).action_done()


### PR DESCRIPTION
The action_done method in stock_inventory_import must return True, because if None is returned it could cause problems with xmlrpc method calls.
