### PR TITLE
[ADD] mrp_operations_extension_manual_close: glue module

### DIFF
--- a/mrp_operations_extension_manual_close/README.rst
+++ b/mrp_operations_extension_manual_close/README.rst
@@ -1,0 +1,43 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================================
+Manufacturing Operations Extension Manual Close
+===============================================
+
+This module adds:
+
+* Launches a wizard to select if undone moves must be done or canceled
+when closed the manufacturing order manually.
+
+Installation
+============
+
+This module is installed automatically when all dependencies are resolved.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/odoomrp/odoomrp-wip/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+

--- a/mrp_operations_extension_manual_close/__init__.py
+++ b/mrp_operations_extension_manual_close/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models
+from . import wizard

--- a/mrp_operations_extension_manual_close/__openerp__.py
+++ b/mrp_operations_extension_manual_close/__openerp__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    'name': 'MRP Operations Extension Manual Close',
+    'version': "8.0.1.1.0",
+    'license': 'AGPL-3',
+    'author': 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Ainara Galdona <ainaragaldona@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        ],
+    'category': 'Manufacturing',
+    'depends': ['mrp_operations_extension',
+                'mrp_production_manual_close'
+                ],
+    'data': ["views/mrp_production_view.xml",
+             ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/mrp_operations_extension_manual_close/i18n/es.po
+++ b/mrp_operations_extension_manual_close/i18n/es.po
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_operations_extension_manual_close
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-14 07:47+0000\n"
+"PO-Revision-Date: 2016-09-14 07:47+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_operations_extension_manual_close
+#: code:addons/mrp_operations_extension_manual_close/models/mrp_production.py:22
+#, python-format
+msgid "Finish MO"
+msgstr "Finalizar OF"
+
+#. module: mrp_operations_extension_manual_close
+#: model:ir.model,name:mrp_operations_extension_manual_close.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Orden de fabricación"
+
+#. module: mrp_operations_extension_manual_close
+#: view:mrp.production:mrp_operations_extension_manual_close.view_mrp_production_form_close
+msgid "object"
+msgstr "object"
+

--- a/mrp_operations_extension_manual_close/models/__init__.py
+++ b/mrp_operations_extension_manual_close/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import mrp_production

--- a/mrp_operations_extension_manual_close/models/mrp_production.py
+++ b/mrp_operations_extension_manual_close/models/mrp_production.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api, _
+
+
+class MrpProduction(models.Model):
+
+    _inherit = 'mrp.production'
+
+    @api.multi
+    def button_produce_close(self):
+        res = {}
+        move_list = self.move_lines.filtered(
+            lambda x: x.state not in('cancel', 'done'))
+        if move_list:
+            idform = self.env.ref(
+                'mrp_operations_extension.finish_wo_form_view')
+            res = {
+                'type': 'ir.actions.act_window',
+                'name': _('Finish MO'),
+                'res_model': 'workcenter.line.finish',
+                'view_type': 'form',
+                'view_mode': 'form',
+                'views': [(idform.id, 'form')],
+                'target': 'new',
+                'context': self.env.context
+                }
+        else:
+            self.signal_workflow('button_produce_close')
+        return res

--- a/mrp_operations_extension_manual_close/tests/__init__.py
+++ b/mrp_operations_extension_manual_close/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_mrp_operations_extension_manual_close

--- a/mrp_operations_extension_manual_close/tests/test_mrp_operations_extension_manual_close.py
+++ b/mrp_operations_extension_manual_close/tests/test_mrp_operations_extension_manual_close.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import openerp.tests.common as common
+
+
+class TestMrpOperationsExtensionManualClose(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMrpOperationsExtensionManualClose, self).setUp()
+        self.production_wiz = self.env['mrp.product.produce']
+        self.production_finish_wiz = self.env['workcenter.line.finish']
+        self.production = self.env.ref(
+            'mrp_operations_extension.mrp_production_opeext')
+        self.production.product_qty = 5
+        self.production.signal_workflow('button_confirm')
+        self.production.force_production()
+
+    def test_production_close_partial_production(self):
+        self.wiz = self.production_wiz.with_context(
+            active_id=self.production.id).create(
+                {'product_id': self.production.product_id.id,
+                 'product_qty': 2,
+                 })
+        self.wiz.with_context(active_id=self.production.id).do_produce()
+        res = self.production.button_produce_close()
+        self.assertEqual(res.get('res_model', False), 'workcenter.line.finish',
+                         'Finish wizard not launched.')
+
+    def test_production_close_complete_production(self):
+        self.wiz = self.production_wiz.with_context(
+            active_id=self.production.id).create(
+                {'product_id': self.production.product_id.id,
+                 'product_qty': 5,
+                 })
+        self.wiz.with_context(active_id=self.production.id).do_produce()
+        res = self.production.button_produce_close()
+        self.assertEqual(res, {}, 'Finish wizard launched.')
+        self.assertEqual(self.production.state, 'done',
+                         'Error production not finished.')
+
+    def test_finish_wizard_cancel(self):
+        self.wiz = self.production_wiz.with_context(
+            active_id=self.production.id).create(
+                {'product_id': self.production.product_id.id,
+                 'product_qty': 2,
+                 })
+        self.wiz.with_context(active_id=self.production.id).do_produce()
+        move_lines = self.production.move_lines
+        dest_move_lines = self.production.move_created_ids
+        finish_wizard = self.production_finish_wiz.with_context(
+            active_model='mrp.production',
+            active_id=self.production.id).create({})
+        finish_wizard.cancel_all()
+        self.assertFalse(move_lines.filtered(lambda x: x.state != 'cancel'),
+                         'Moves state is not cancel.')
+        self.assertFalse(dest_move_lines.filtered(lambda x:
+                                                  x.state != 'cancel'),
+                         'Moves state is not cancel.')
+
+    def test_finish_wizard_done(self):
+        self.wiz = self.production_wiz.with_context(
+            active_id=self.production.id).create(
+                {'product_id': self.production.product_id.id,
+                 'product_qty': 2,
+                 })
+        self.wiz.with_context(active_id=self.production.id).do_produce()
+        move_lines = self.production.move_lines
+        dest_move_lines = self.production.move_created_ids
+        finish_wizard = self.production_finish_wiz.with_context(
+            active_model='mrp.production',
+            active_id=self.production.id).create({})
+        finish_wizard.make_them_done()
+        self.assertFalse(move_lines.filtered(lambda x: x.state != 'done'),
+                         'Moves state is not done.')
+        self.assertFalse(dest_move_lines.filtered(lambda x: x.state != 'done'),
+                         'Moves state is not done.')

--- a/mrp_operations_extension_manual_close/views/mrp_production_view.xml
+++ b/mrp_operations_extension_manual_close/views/mrp_production_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_mrp_production_form_close" model="ir.ui.view">
+            <field name="name">mrp.production.form.close</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp_production_manual_close.view_mrp_production_form_close" />
+            <field name="arch" type="xml">
+                <data>
+                    <button name="button_produce_close" position="attributes">
+                         <attribute name="type">object</attribute>
+                    </button>
+                </data>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/mrp_operations_extension_manual_close/wizard/__init__.py
+++ b/mrp_operations_extension_manual_close/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import workcenter_line_finish

--- a/mrp_operations_extension_manual_close/wizard/workcenter_line_finish.py
+++ b/mrp_operations_extension_manual_close/wizard/workcenter_line_finish.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class WorkcenterLineFinish(models.TransientModel):
+
+    _inherit = "workcenter.line.finish"
+
+    @api.multi
+    def make_them_done(self):
+        if ('active_id' in self.env.context and
+                (self.env.context.get('active_model', False) ==
+                 'mrp.production')):
+            production_obj = self.env['mrp.production']
+            production = production_obj.browse(self.env.context['active_id'])
+            (production.move_lines | production.move_created_ids).action_done()
+            production.signal_workflow('button_produce_close')
+        else:
+            return super(WorkcenterLineFinish, self).make_them_done()
+
+    @api.multi
+    def cancel_all(self):
+        if ('active_id' in self.env.context and
+                (self.env.context.get('active_model', False) ==
+                 'mrp.production')):
+            production_obj = self.env['mrp.production']
+            production = production_obj.browse(self.env.context['active_id'])
+            (production.move_lines |
+             production.move_created_ids).action_cancel()
+            production.signal_workflow('button_produce_close')
+        else:
+            return super(WorkcenterLineFinish, self).make_them_done()


### PR DESCRIPTION
New module to launch finish wizard when closing partial produced manufacturing orders. This wizard will give an option to cancel all pending moves or to done them.
