### PR TITLE
[FIX] mrp_product_variants_operations: Cycled when trying to change t…

### DIFF
--- a/mrp_product_variants_operations/models/mrp_production.py
+++ b/mrp_product_variants_operations/models/mrp_production.py
@@ -59,3 +59,11 @@ class MrpProduction(models.Model):
                 self.with_context(phantom_op=phantom_op)._set_workorder(
                     bom_obj.browse(bom_id), p_line,  workcenter_lines,
                     properties=properties)
+
+    @api.multi
+    def write(self, vals, update=True, mini=True):
+        if vals.get('date_start', False) and len(self) == 1:
+            if self.date_start and vals.get('date_start') >= self.date_start:
+                vals.pop('date_start')
+        return super(MrpProduction, self).write(
+            vals, update=update, mini=mini)

--- a/mrp_product_variants_operations/tests/__init__.py
+++ b/mrp_product_variants_operations/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_mrp_product_variants_operations

--- a/mrp_product_variants_operations/tests/test_mrp_product_variants_operations.py
+++ b/mrp_product_variants_operations/tests/test_mrp_product_variants_operations.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestMrpProductVariantsOperations(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMrpProductVariantsOperations, self).setUp()
+        self.production = self.env.ref(
+            'mrp_operations_extension.mrp_production_opeext')
+
+    def test_mrp_product_variants_operations(self):
+        self.assertEqual(self.production.state, 'draft')
+        self.production.signal_workflow('button_confirm')
+        lines = self.production.product_lines.filtered(
+            lambda x: not x.work_order or not x.product_id)
+        self.assertEqual(
+            len(lines), 0,
+            'Scheduled goods without work order, or without product')


### PR DESCRIPTION
…he start date of the MO.
Cuando se intenta modificar la fecha de inicio de la órden de fabricación, con una fecha igual a la que tiene, se cicla el proceso del botón "Calcular Datos" de la órde de producción.