### PR TITLE
[FIX] mrp_production_machine_location: Treat work orders that do not …

### DIFF
--- a/mrp_production_machine_location/README.rst
+++ b/mrp_production_machine_location/README.rst
@@ -1,13 +1,16 @@
 MRP Production machine location
 ===============================
-If the work order is to produce, and this work order has a work center that has
-a machine defined, and this machine has definied a location:
+If the work order has a work center that has a machine defined, and this
+machine has definied a location:
 
- * The origin location of the products to consume in the work order, will be
- the location of the machine.
+* The origin location of the products to consume in the work order, will be
+  the location of the machine.
 
- * The destination location of the product to be produced, will be the location
- of the machine.
+And in the work order in which the product is produced, has a machine defined,
+and this machine has definied a location:
+
+* The destination location of the product to be produced, will be the location
+  of the machine.
 
 
 Configuration

--- a/mrp_production_machine_location/models/stock_move.py
+++ b/mrp_production_machine_location/models/stock_move.py
@@ -10,7 +10,6 @@ class StockMove(models.Model):
     @api.multi
     def action_confirm(self):
         moves = self.filtered(lambda r: r.raw_material_production_id and
-                              r.work_order.do_production and
                               r.work_order.workcenter_id.machine.location)
         for move in moves:
             location = move.work_order.workcenter_id.machine.location


### PR DESCRIPTION
…produce products.
Tratar "Work orders" que no producen productos, esto afecta a movimientos de productos a consumir que antes no se trataban.