### PR TITLE
[IMP] mrp_product_variants: delete default domain

### DIFF
--- a/mrp_product_variants/views/mrp_production_view.xml
+++ b/mrp_product_variants/views/mrp_production_view.xml
@@ -19,6 +19,7 @@
                 <xpath expr="//field[@name='bom_line_ids']//field[@name='attribute_value_ids']"
                        position="attributes">
                     <attribute name="options">{'no_create': True}</attribute>
+                    <attribute name="domain" />
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Se elimino está línea en https://github.com/odoomrp/odoomrp-wip/commit/7ccdf654d79a8f14df2763a00f268834377f5cf4#diff-0ac97c08c3bad0031f23566211c42f7aL22

segun @Daniel-CA:

> El tema está en la función que define si el producto definido en el BoM es apto para la variante, tal y como esta enfocada en este momento se deben cumplir todas las variantes en la linea para que el producto se añada. Por lo que si un componente en el BoM tiene las variantes de Grande y Pequeño definidas en la misma linea, a la hora de fabricar un producto con cualquiera de esas dos variantes no se añadirá ya que no cumple las dos (cosa que no ocurrirá nunca ya que se excluyen mutuamente).

> Otro enfoque sería que se añada en caso de que cumpla cualquiera de las dos variantes, pero de hacerse así si queremos añadir variantes de otro tipo habría que hacerlo de forma diferente ya que puede que el componente solo se tenga que añadir si se cumplen que sea Grande y Negro por ejemplo.