### PR TITLE
[ADD] stock_inventory_import: When cancel unlink import lines.

### DIFF
--- a/stock_inventory_import/models/stock_inventory.py
+++ b/stock_inventory_import/models/stock_inventory.py
@@ -84,3 +84,8 @@ class StockInventory(models.Model):
                     _("Loaded lines must be processed at least one time for "
                       "inventory : %s") % (inventory.name))
         return super(StockInventory, self).action_done()
+
+    @api.multi
+    def action_cancel_inventory(self):
+        self.mapped("import_lines").unlink()
+        return super(StockInventory, self).action_cancel_inventory()


### PR DESCRIPTION
Delete the import lines to avoid duplicates when canceling an inventory adjustment and import again.