### PR TITLE
[8.0] Several improvements on stock_quant_packages_moving_wizard

### DIFF
--- a/stock_quant_packages_moving_wizard/__openerp__.py
+++ b/stock_quant_packages_moving_wizard/__openerp__.py
@@ -22,6 +22,7 @@
         "wizard/quant_move_wizard_view.xml",
         "wizard/quants_move_wizard_view.xml",
         "wizard/quant_packages_move_wizard_view.xml",
+        "views/stock_view.xml",
     ],
     "installable": True,
 }

--- a/stock_quant_packages_moving_wizard/models/stock.py
+++ b/stock_quant_packages_moving_wizard/models/stock.py
@@ -29,6 +29,12 @@ class StockQuant(models.Model):
 
     @api.one
     def move_to(self, dest_location):
+        # if the quant is reserved for another move,
+        # we should cleanly un-reserve it first, so that
+        # the picking that booked this quant comes back from
+        # available to waiting availability
+        if self.reservation_id:
+            self.reservation_id.do_unreserve()
         vals = self._prepare_move_to(dest_location)
         new_move = self.env['stock.move'].create(vals)
         # No group has write access on stock.quant -> we need sudo()

--- a/stock_quant_packages_moving_wizard/models/stock.py
+++ b/stock_quant_packages_moving_wizard/models/stock.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import api, fields, models
+from openerp import api, fields, models, _
 from openerp.tools.float_utils import float_compare
 
 
 class StockQuant(models.Model):
     _inherit = 'stock.quant'
 
-    @api.one
-    def move_to(self, dest_location):
-        move_obj = self.with_context(quant_moving=True).env['stock.move']
-        new_move = move_obj.create({
-            'name': 'Move %s to %s' % (self.product_id.name,
-                                       dest_location.name),
+    @api.multi
+    def _prepare_move_to(self, dest_location):
+        self.ensure_one()
+        vals = {
+            'name': '%s: Move to %s' % (
+                self.product_id.name_get()[0][1],
+                dest_location.complete_name),
             'product_id': self.product_id.id,
             'location_id': self.location_id.id,
             'location_dest_id': dest_location.id,
@@ -21,18 +22,23 @@ class StockQuant(models.Model):
             'product_uom': self.product_id.uom_id.id,
             'date_expected': fields.Datetime.now(),
             'date': fields.Datetime.now(),
-            'quant_ids': [(4, self.id)],
-            'restrict_lot_id': self.lot_id.id
-        })
-        new_move.action_done()
+            'reserved_quant_ids': [(4, self.id)],
+            'restrict_lot_id': self.lot_id.id,
+            'origin': _('Quant Move'),
+        }
+        return vals
+
+    @api.one
+    def move_to(self, dest_location):
+        vals = self._prepare_move_to(dest_location)
+        new_move = self.env['stock.move'].create(vals)
+        new_move.with_context(quant_moving=True).action_done()
 
     @api.model
     def quants_get_prefered_domain(
             self, location, product, qty, domain=None,
-            prefered_domain_list=None, restrict_lot_id=False,
+            prefered_domain_list=[], restrict_lot_id=False,
             restrict_partner_id=False):
-        if prefered_domain_list is None:
-            prefered_domain_list = []
         quants = super(StockQuant, self).quants_get_prefered_domain(
             location, product, qty, domain=domain,
             prefered_domain_list=prefered_domain_list,
@@ -40,7 +46,7 @@ class StockQuant(models.Model):
             restrict_partner_id=restrict_partner_id)
         if location.usage not in ['inventory', 'production', 'supplier']:
             return quants
-        if self.env.context.get('quant_moving', False):
+        if self.env.context.get('quant_moving'):
             if domain is None:
                 domain = []
             res_qty = qty

--- a/stock_quant_packages_moving_wizard/models/stock.py
+++ b/stock_quant_packages_moving_wizard/models/stock.py
@@ -22,7 +22,6 @@ class StockQuant(models.Model):
             'product_uom': self.product_id.uom_id.id,
             'date_expected': fields.Datetime.now(),
             'date': fields.Datetime.now(),
-            'reserved_quant_ids': [(4, self.id)],
             'restrict_lot_id': self.lot_id.id,
             'origin': _('Quant Move'),
         }
@@ -32,6 +31,8 @@ class StockQuant(models.Model):
     def move_to(self, dest_location):
         vals = self._prepare_move_to(dest_location)
         new_move = self.env['stock.move'].create(vals)
+        # No group has write access on stock.quant -> we need sudo()
+        self.sudo().reservation_id = new_move
         new_move.with_context(quant_moving=True).action_done()
 
     @api.model

--- a/stock_quant_packages_moving_wizard/views/stock_view.xml
+++ b/stock_quant_packages_moving_wizard/views/stock_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+<data>
+
+<record id="view_stock_quant_form" model="ir.ui.view">
+    <field name="name">move_wizard.stock.quant.form</field>
+    <field name="model">stock.quant</field>
+    <field name="inherit_id" ref="stock.view_stock_quant_form"/>
+    <field name="arch" type="xml">
+        <button name="action_view_quant_history" position="before">
+            <button name="%(action_move_quants)d" type="action" string="Move to Another Location"/>
+        </button>
+    </field>
+</record>
+
+<record id="view_quant_package_form" model="ir.ui.view">
+    <field name="name">move_wizard.stock.quant.package.form</field>
+    <field name="model">stock.quant.package</field>
+    <field name="inherit_id" ref="stock.view_quant_package_form"/>
+    <field name="arch" type="xml">
+        <button name="unpack" position="before">
+            <button name="%(action_move_packages)d" type="action" string="Move to Another Location"/>
+        </button>
+    </field>
+</record>
+
+</data>
+</openerp>

--- a/stock_quant_packages_moving_wizard/wizard/quant_move_wizard.py
+++ b/stock_quant_packages_moving_wizard/wizard/quant_move_wizard.py
@@ -23,7 +23,11 @@ class StockQuantMove(models.TransientModel):
         items = []
         for quant in quants:
             if not quant.package_id:
-                items.append({'quant': quant.id})
+                items.append({
+                    'quant': quant.id,
+                    # source_loc is needed even if it's a related field...
+                    'source_loc': quant.location_id.id,
+                    })
         res.update(pack_move_items=items)
         return res
 

--- a/stock_quant_packages_moving_wizard/wizard/quant_move_wizard_view.xml
+++ b/stock_quant_packages_moving_wizard/wizard/quant_move_wizard_view.xml
@@ -2,17 +2,17 @@
 <openerp>
     <data>
         <record id="stock_quant_move_wizard" model="ir.ui.view">
-            <field name="name">Enter transfer details</field>
+            <field name="name">stock.quant.move.wizard.form</field>
             <field name="model">stock.quant.move</field>
             <field name="arch" type="xml">
-                <form string="Transfer details" version="7">
-                    <group groups="stock.group_tracking_lot">
-                        <field name="pack_move_items"
-                            nolabel="1">
+                <form string="Transfer details">
+                    <group name="main">
+                        <field name="pack_move_items" nolabel="1">
                             <tree editable="bottom">
                                 <field name="quant" />
                                 <field name="source_loc" />
-                                <field name="dest_loc" />
+                                <field name="dest_loc"
+                                    domain="[('id', '!=', source_loc)]"/>
                             </tree>
                         </field>
                     </group>
@@ -27,8 +27,9 @@
             </field>
         </record>
 
-        <act_window name="Move Stock Quant" groups="stock.group_tracking_lot"
+        <act_window name="Move Quant"
             res_model="stock.quant.move" src_model="stock.quant"
             view_mode="form" target="new" key2="client_action_multi" id="action_move_quants" />
+
     </data>
 </openerp>

--- a/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard.py
+++ b/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard.py
@@ -22,7 +22,11 @@ class StockQuantPackageMove(models.TransientModel):
         items = []
         for package in packages:
             if not package.parent_id and package.location_id:
-                items.append({'package': package.id})
+                items.append({
+                    'package': package.id,
+                    # source_loc is needed even if it's a related field...
+                    'source_loc': package.location_id.id,
+                    })
         res.update(pack_move_items=items)
         return res
 

--- a/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard.py
+++ b/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard.py
@@ -12,8 +12,8 @@ class StockQuantPackageMove(models.TransientModel):
         string='Packs')
 
     @api.model
-    def default_get(self, fields):
-        res = super(StockQuantPackageMove, self).default_get(fields)
+    def default_get(self, fields_list):
+        res = super(StockQuantPackageMove, self).default_get(fields_list)
         packages_ids = self.env.context.get('active_ids', [])
         if not packages_ids:
             return res
@@ -22,16 +22,13 @@ class StockQuantPackageMove(models.TransientModel):
         items = []
         for package in packages:
             if not package.parent_id and package.location_id:
-                item = {
-                    'package': package.id,
-                    'source_loc': package.location_id.id,
-                }
-                items.append(item)
+                items.append({'package': package.id})
         res.update(pack_move_items=items)
         return res
 
-    @api.one
+    @api.multi
     def do_detailed_transfer(self):
+        self.ensure_one()
         for item in self.pack_move_items:
             if item.dest_loc is not item.source_loc:
                 for quant in item.package.quant_ids:
@@ -50,14 +47,11 @@ class StockQuantPackageMoveItems(models.TransientModel):
         comodel_name='stock.quant.package.move', string='Package move')
     package = fields.Many2one(
         comodel_name='stock.quant.package', string='Quant package',
+        required=True,
         domain=[('parent_id', '=', False), ('location_id', '!=', False)])
     source_loc = fields.Many2one(
-        comodel_name='stock.location', string='Source Location', required=True)
+        string='Current Location', related='package.location_id',
+        readonly=True)
     dest_loc = fields.Many2one(
         comodel_name='stock.location', string='Destination Location',
         required=True)
-
-    @api.one
-    @api.onchange('package')
-    def onchange_quant(self):
-        self.source_loc = self.package.location_id

--- a/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard_view.xml
+++ b/stock_quant_packages_moving_wizard/wizard/quant_packages_move_wizard_view.xml
@@ -2,17 +2,17 @@
 <openerp>
     <data>
         <record id="stock_quant_package_move_wizard" model="ir.ui.view">
-            <field name="name">Enter transfer details</field>
+            <field name="name">stock.quant.package.move.wizard.form</field>
             <field name="model">stock.quant.package.move</field>
             <field name="arch" type="xml">
-                <form string="Transfer details" version="7">
-                    <group groups="stock.group_tracking_lot">
-                        <field name="pack_move_items"
-                            nolabel="1">
+                <form string="Package Transfer details">
+                    <group name="main">
+                        <field name="pack_move_items" nolabel="1">
                             <tree editable="bottom">
                                 <field name="package" />
                                 <field name="source_loc" />
-                                <field name="dest_loc" />
+                                <field name="dest_loc"
+                                    domain="[('id', '!=', source_loc)]" />
                             </tree>
                         </field>
                     </group>
@@ -27,7 +27,7 @@
             </field>
         </record>
 
-        <act_window name="Move Stock Quant Packages" groups="stock.group_tracking_lot"
+        <act_window name="Move Packages" groups="stock.group_tracking_lot"
             res_model="stock.quant.package.move" src_model="stock.quant.package"
             view_mode="form" target="new" key2="client_action_multi" id="action_move_packages" />
     </data>

--- a/stock_quant_packages_moving_wizard/wizard/quants_move_wizard_view.xml
+++ b/stock_quant_packages_moving_wizard/wizard/quants_move_wizard_view.xml
@@ -2,14 +2,13 @@
 <openerp>
     <data>
         <record id="stock_quants_move_wizard" model="ir.ui.view">
-            <field name="name">Enter transfer details</field>
+            <field name="name">stock.quants.move.wizard.form</field>
             <field name="model">stock.quants.move</field>
             <field name="arch" type="xml">
-                <form string="Transfer details" version="7">
-                    <group groups="stock.group_tracking_lot">
+                <form string="Transfer details">
+                    <group name="main">
                         <field name="dest_loc" />
-                        <field name="pack_move_items"
-                            nolabel="1" colspan="2">
+                        <field name="pack_move_items" nolabel="1" colspan="2">
                             <tree editable="bottom">
                                 <field name="quant" />
                                 <field name="source_loc" />
@@ -30,14 +29,12 @@
         <record id="action_move_quants_to" model="ir.actions.act_window">
             <field name="name">Move Stock Quants To</field>
             <field name="res_model">stock.quants.move</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">tree,form</field>
-            <field name="view_id" ref="stock_quants_move_wizard"/>
+            <field name="view_mode">form</field>
             <field name="target">new</field>
         </record>
 
         <menuitem action="action_move_quants_to" id="menu_quant_move_wizard"
-            parent="stock.menu_traceability" groups="stock.group_tracking_lot"
+            parent="stock.menu_traceability"
             sequence="100"/>
     </data>
 </openerp>


### PR DESCRIPTION
Add a test to show that the stock.quant.package.move wizard doesn't work ! => I don't know how to make it work, but at least this test is a demo that it fails !

Use reserved_quant_ids in stock.move instead of quant_ids (I think it's the right thing to do, but I'm not an expert)
Add prepare method for stock move creation and add origin field by default
Use 'fields_list' instead of 'fields' argument in default_get to avoid confusion with "fields" from "from openerp import fields"
Add visible button on form view of stock.quant and stock.quant.package
Block selection of destination location = source location in wizard
Rename 'Source Location' to 'Current Location' in wizard (and other string improvements)
Use related field for source location instead of onchange
Give access to button "move quant" on stock.quant even if not in group stock.group_tracking_lot (but keep it for the button on stock.quant.package)
Display moved quants after execution of the stock.quants.move wizard