### PR TITLE
[FIX] mrp_production_machine_location: show error "Not work order fou…

### DIFF
--- a/mrp_production_machine_location/i18n/es.po
+++ b/mrp_production_machine_location/i18n/es.po
@@ -25,3 +25,13 @@ msgstr "Orden de fabricación"
 msgid "Stock Move"
 msgstr "Movimiento de stock"
 
+#. module: mrp_production_machine_location
+#: code:addons/mrp_production_machine_location/models/mrp_production.py:18
+#, python-format
+msgid ""
+"Not work order found with 'Produce here', you should surely enter the "
+"'Routing' in the production order."
+msgstr ""
+"Órden de trabajo con 'Producir aquí' no encontrada, seguramente deba de "
+"introducir la 'Ruta' en la órden de producción."
+

--- a/mrp_production_machine_location/models/mrp_production.py
+++ b/mrp_production_machine_location/models/mrp_production.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2016 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from openerp import models, api
+from openerp import models, api, exceptions, _
 
 
 class MrpProduction(models.Model):
@@ -13,6 +13,10 @@ class MrpProduction(models.Model):
         for prod in self:
             workcenter_lines = prod.workcenter_lines.filtered(
                 lambda r: r.do_production)
+            if not workcenter_lines:
+                raise exceptions.Warning(
+                    _("Not work order found with 'Produce here', you should"
+                      " surely enter the 'Routing' in the production order."))
             workcenter_line = max(
                 workcenter_lines, key=lambda x: x.sequence)
             location = workcenter_line.workcenter_id.machine.location

--- a/mrp_production_machine_location/tests/test_mrp_production_machine_location.py
+++ b/mrp_production_machine_location/tests/test_mrp_production_machine_location.py
@@ -2,6 +2,7 @@
 # (c) 2015 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 import openerp.tests.common as common
+from openerp import exceptions
 
 
 class TestMrpProductionMachineLocation(common.TransactionCase):
@@ -17,6 +18,11 @@ class TestMrpProductionMachineLocation(common.TransactionCase):
 
     def test_mrp_production_machine_location(self):
         self.assertEqual(self.production.state, 'draft')
+        old_routing_id = self.production.routing_id.id
+        self.production.routing_id = False
+        with self.assertRaises(exceptions.Warning):
+            self.production.signal_workflow('button_confirm')
+        self.production.routing_id = old_routing_id
         self.production.signal_workflow('button_confirm')
         stock_moves = self.production.mapped('move_lines').filtered(
             lambda l: l.work_order.workcenter_id == self.workcenter)


### PR DESCRIPTION
…nd with 'Produce here', you should surely enter the 'Routing' in the production order".

Show error when a production order is confirmed, and no "work order" is found, with "Produce here" checked.
