### PR TITLE
[8.0] New option of grouping one_sale_one_purchase

### DIFF
--- a/procurement_purchase_no_grouping/README.rst
+++ b/procurement_purchase_no_grouping/README.rst
@@ -24,3 +24,4 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <ajuaristo@gmail.com>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Daniel Rodriguez Lijo <drl.9319@gmail.com>

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -17,10 +17,12 @@
 ##############################################################################
 {
     "name": "Procurement Purchase No Grouping",
-    "version": "1.0",
-    "author": "OdooMRP team,"
+    "version": "8.0.1.0",
+    "author": "Odoo Community Association (OCA),"
+              "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "license": "AGPL-3",
     "website": "http://www.odoomrp.com",
     "category": "Procurements",
     "depends": ['purchase',

--- a/procurement_purchase_no_grouping/__openerp__.py
+++ b/procurement_purchase_no_grouping/__openerp__.py
@@ -17,7 +17,7 @@
 ##############################################################################
 {
     "name": "Procurement Purchase No Grouping",
-    "version": "8.0.1.0",
+    "version": "8.0.1.0.0",
     "author": "Odoo Community Association (OCA),"
               "OdooMRP team,"
               "AvanzOSC,"

--- a/procurement_purchase_no_grouping/models/procurement_order.py
+++ b/procurement_purchase_no_grouping/models/procurement_order.py
@@ -11,5 +11,6 @@ class ProcurementOrder(models.Model):
     @api.multi
     def make_po(self):
         obj = self.with_context(
-            grouping=self.product_id.categ_id.procured_purchase_grouping)
+            grouping=self.product_id.categ_id.procured_purchase_grouping,
+            origin=self.origin)
         return super(ProcurementOrder, obj).make_po()

--- a/procurement_purchase_no_grouping/models/product_category.py
+++ b/procurement_purchase_no_grouping/models/product_category.py
@@ -11,7 +11,8 @@ class ProductCategory(models.Model):
     procured_purchase_grouping = fields.Selection(
         [('standard', 'Standard grouping'),
          ('line', 'No line grouping'),
-         ('order', 'No order grouping')],
+         ('order', 'No order grouping'),
+         ('one_sale_one_purchase', 'One sale, One purchase')],
         string='Procured purchase grouping', default='standard',
         help="Select the behaviour for grouping procured purchases for the "
              "the products of this category:\n"
@@ -22,4 +23,6 @@ class ProductCategory(models.Model):
              "the same supplier, it will be reused, but lines won't be "
              "merged.\n"
              "* No order grouping: This option will prevent any kind of "
-             "grouping.")
+             "grouping.\n"
+             "* One sale, One purchase: This option group all lines for same"
+             "suplier in one purchase order from the same sale order.")

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -24,9 +24,7 @@ class PurchaseOrder(models.Model):
 
             # Add new condition to domain, becouse I need find only one
             # purchase order with de same suplier and origin to add new line
-            aux = args
-            aux.append(('origin', '=', context.get('origin', False)))
-            arg = aux
+            args.append(('origin', '=', context.get('origin', False)))
         return super(PurchaseOrder, self).search(
             cr, uid, args, offset=offset, limit=limit, order=order,
             context=context, count=count)

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -21,10 +21,9 @@ class PurchaseOrder(models.Model):
         if (context and
                 context.get('grouping', 'standard') == 'one_sale_one_purchase'
                 and make_po_conditions.issubset(set(x[0] for x in args))):
-            '''
-                Add new condition to domain, becouse I need find only one
-                purchase order with de same suplier and origin to add new line
-            '''
+
+            # Add new condition to domain, becouse I need find only one
+            # purchase order with de same suplier and origin to add new line
             aux = args
             aux.append(('origin', '=', context.get('origin', False)))
             arg = aux

--- a/procurement_purchase_no_grouping/models/purchase_order.py
+++ b/procurement_purchase_no_grouping/models/purchase_order.py
@@ -17,6 +17,17 @@ class PurchaseOrder(models.Model):
         if (context and context.get('grouping', 'standard') == 'order' and
                 make_po_conditions.issubset(set(x[0] for x in args))):
             return []
+        # If grouping is one purchase order from same sale order
+        if (context and
+                context.get('grouping', 'standard') == 'one_sale_one_purchase'
+                and make_po_conditions.issubset(set(x[0] for x in args))):
+            '''
+                Add new condition to domain, becouse I need find only one
+                purchase order with de same suplier and origin to add new line
+            '''
+            aux = args
+            aux.append(('origin', '=', context.get('origin', False)))
+            arg = aux
         return super(PurchaseOrder, self).search(
             cr, uid, args, offset=offset, limit=limit, order=order,
             context=context, count=count)

--- a/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
+++ b/procurement_purchase_no_grouping/tests/test_procurement_purchase_no_grouping.py
@@ -77,3 +77,19 @@ class TestProcurementPurchaseNoGrouping(TransactionCase):
             self.procurement_2.purchase_line_id,
             'Procured purchase orders lines are the same')
         return True
+
+    def test_procurement_one_sale_one_purchase(self):
+        self.category.procured_purchase_grouping = 'one_sale_one_purchase'
+        self.procurement_1.run()
+        self.procurement_2.run()
+        self.assertTrue(self.procurement_1.purchase_id)
+        self.assertTrue(self.procurement_2.purchase_id)
+        self.assertNotEqual(
+            self.procurement_1.purchase_id,
+            self.procurement_2.purchase_id,
+            'Procured purchase orders are the same')
+        self.assertNotEqual(
+            self.procurement_1.purchase_line_id,
+            self.procurement_2.purchase_line_id,
+            'Procured purchase orders lines are the same')
+        return True


### PR DESCRIPTION
I create new option (One Sale, One Purchase) in procurement_purchase_no_groping to add new funcionality.
This funcionality make that: One sale order create only one purchase order for supllier with all related lines. This funcion make that only groping purchase order from de same sale order. 