### PR TITLE
[FIX] stock_inventory_import, make standard_price optional

### DIFF
--- a/stock_inventory_import/wizard/import_inventory.py
+++ b/stock_inventory_import/wizard/import_inventory.py
@@ -90,7 +90,8 @@ class ImportInventory(models.TransientModel):
             val['inventory_id'] = inventory.id
             val['fail'] = True
             val['fail_reason'] = _('No processed')
-            val['standard_price'] = values['standard_price']
+            if 'standard_price' in values and values['standard_price']:
+                val['standard_price'] = values['standard_price']
             inv_imporline_obj.create(val)
 
 


### PR DESCRIPTION
Hi:
In the fd69c05 commit from #1278 issue, the `standard_price` field is introduced. But this field is required, otherwise a `KeyError: 'standar_price'` raises. I propose some changes in order to do this field optional on stock inventory import by file.
