### PR TITLE
[FIX][8.0]mrp_production_traceability: Fix wrong relation

### DIFF
--- a/mrp_production_traceability/models/stock_move.py
+++ b/mrp_production_traceability/models/stock_move.py
@@ -12,4 +12,4 @@ class StockMove(models.Model):
                                       'Parent production lot')
     final_product = fields.Many2one(
         'product.product', string='Final Product', store=True,
-        related='production_id.product_id', help='Production Final Product')
+        related='raw_material_production_id.product_id', help='Production Final Product')


### PR DESCRIPTION
The relation was targeting the wrong production field.