### PR TITLE
[IMP] quality_control_mrp_operations: inspections do not have production_id

### DIFF
--- a/quality_control_mrp_operations/models/mrp.py
+++ b/quality_control_mrp_operations/models/mrp.py
@@ -109,7 +109,6 @@ class MrpProductionWorkcenterLine(models.Model):
     def create_quality_test(self, qtemplate):
         vals = {
             'workcenter_line_id': self.id,
-            'production_id': self.production_id.id,
             'test': qtemplate.id,
         }
         if qtemplate.object_id:


### PR DESCRIPTION
qc.inspection.create() with unknown fields: production_id

https://travis-ci.org/odoomrp/odoomrp-wip/jobs/239545859#L2167 warning shown in travis log