### PR TITLE
[FIX][8.0] Error when new product without line attributes from template

### DIFF
--- a/product_variants_no_automatic_creation/models/product_configurator.py
+++ b/product_variants_no_automatic_creation/models/product_configurator.py
@@ -40,7 +40,7 @@ class ProductConfigurator(models.AbstractModel):
         # First, empty current list
         self.product_attribute_ids = [
             (2, x.id) for x in self.product_attribute_ids]
-                if not self.env.context.get('not_reset_product'):
+        if not self.env.context.get('not_reset_product'):
             self.product_id = False
         attribute_list = []
         for attribute_line in self.product_tmpl_id.attribute_line_ids:

--- a/product_variants_no_automatic_creation/models/product_configurator.py
+++ b/product_variants_no_automatic_creation/models/product_configurator.py
@@ -40,20 +40,17 @@ class ProductConfigurator(models.AbstractModel):
         # First, empty current list
         self.product_attribute_ids = [
             (2, x.id) for x in self.product_attribute_ids]
-        if not self.product_tmpl_id.attribute_line_ids:
-            self.product_id = self.product_tmpl_id.product_variant_ids
-        else:
-            if not self.env.context.get('not_reset_product'):
-                self.product_id = False
-            attribute_list = []
-            for attribute_line in self.product_tmpl_id.attribute_line_ids:
-                attribute_list.append({
-                    'attribute_id': attribute_line.attribute_id.id,
-                    'product_tmpl_id': self.product_tmpl_id.id,
-                    'owner_model': self._name,
-                    'owner_id': self.id,
-                })
-            self.product_attribute_ids = [(0, 0, x) for x in attribute_list]
+                if not self.env.context.get('not_reset_product'):
+            self.product_id = False
+        attribute_list = []
+        for attribute_line in self.product_tmpl_id.attribute_line_ids:
+            attribute_list.append({
+                'attribute_id': attribute_line.attribute_id.id,
+                'product_tmpl_id': self.product_tmpl_id.id,
+                'owner_model': self._name,
+                'owner_id': self.id,
+            })
+        self.product_attribute_ids = [(0, 0, x) for x in attribute_list]
         # Needed because the compute method is not triggered
         self.product_attribute_ids._compute_possible_value_ids()
         # Restrict product possible values to current selection


### PR DESCRIPTION
If list variant products from templates and your create new product with a template without line attributes, it crash.
ValueError: Wrong value for product.product.product_id: product.product(<openerp.models.NewId object at 0x746cb0918b50>, 31)