### PR TITLE
[FIX] mrp_production_add_middle_stuff_lot: link new lot to product

### DIFF
--- a/mrp_production_add_middle_stuff_lot/wizard/addition_wizard_view.xml
+++ b/mrp_production_add_middle_stuff_lot/wizard/addition_wizard_view.xml
@@ -8,7 +8,7 @@
             <field name="type">form</field>
             <field name="arch" type="xml">
                 <field name="production_id" position="after">
-                    <field name="lot" domain="[('product_id','=', product_id)]" groups="stock.group_production_lot" colspan="2"/>
+                    <field name="lot" domain="[('product_id','=', product_id)]" context="{'default_product_id': product_id}" groups="stock.group_production_lot" colspan="2"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
If you create a lot when adding a new product to consume, the lot is missing the link to the product just selected