### PR TITLE
[FIX] mrp_subcontracting: if picking type is empty, no picking as to be created at PO confirmation

### DIFF
--- a/mrp_subcontracting/models/purchase_order.py
+++ b/mrp_subcontracting/models/purchase_order.py
@@ -25,6 +25,8 @@ class PurchaseOrder(models.Model):
                 if move.work_order.id == self.mrp_operation.id:
                     if not picking:
                         wc_line = self.mrp_operation.routing_wc_line
+                        if not wc_line.picking_type_id:
+                            continue
                         vals = {'origin': self.mrp_operation.name,
                                 'picking_type_id': wc_line.picking_type_id.id,
                                 'invoice_state': 'none',


### PR DESCRIPTION
When the picking type is empty, it raises an exception as it tries to create a picking without picking type and this field is a required in a picking.

In my scenario, all raw materials are provided directly at the subcontractor and the finished product is send trough transit operation to next subcontractor or though delivery order to end-customer.
There is no main warehouse and so no picking in/out to the main warehouse. All is manufactured though several subcontractors.
The MO generates a PO to the subcontractor with a service line (cost of the manufacturing)
This scenario works properly with provided odoomrp modules except PO cannot be confirmed without this fix.