### PR TITLE
[FIX] purchase_landed_cost: Exception with incorrect param

### DIFF
--- a/purchase_landed_cost/models/purchase_cost_distribution.py
+++ b/purchase_landed_cost/models/purchase_cost_distribution.py
@@ -179,7 +179,7 @@ class PurchaseCostDistribution(models.Model):
             raise exceptions.UserError(
                 _("The cost for the line '%s' can't be "
                   "distributed because the calculation method "
-                  "doesn't provide valid data" % cost_line.type.name))
+                  "doesn't provide valid data" % expense_line.type.name))
         return {
             'distribution_expense': expense_line.id,
             'expense_amount':       expense_amount,


### PR DESCRIPTION
Related issue in v8.0 https://github.com/odoomrp/odoomrp-wip/commit/d49e655751d110c532a738fc7371cd41f1252aa5.